### PR TITLE
Integrate Immersive Scaler

### DIFF
--- a/resources/translations.csv
+++ b/resources/translations.csv
@@ -2,17 +2,17 @@ name,en_US,ja_JP,ko_KR
 Main.error.restartAdmin,"
 
 Faulty CATS installation found!
-To fix this restart Blender as admin!     
+To fix this restart Blender as admin!
 ",,"
 
 잘못 설치된 Cats Plugin이 발견되었습니다!
-이 문제를 해결하려면 Blender를 관리자로 다시 시작하세요!     
+이 문제를 해결하려면 Blender를 관리자로 다시 시작하세요!
 "
-Main.error.deleteFollowing,"                                                                                                                                                                                                         
+Main.error.deleteFollowing,"
 
 Faulty CATS installation found!
 To fix this delete the following files and folders inside your addons folder:
-",,"                                                                                                                                                                                                         
+",,"
 
 잘못 설치된 Cats Plugin이 발견되었습니다!
 이 문제를 해결하려면 addons 폴더에서 다음 파일과 폴더를 삭제하세요.:
@@ -37,11 +37,11 @@ Blender를 다시 시작하고 Cats Plugin를 다시 활성화하세요!
 "
 Main.error.unsupportedVersion,"
 
-Blender versions older than 2.79 are not supported by Cats. 
+Blender versions older than 2.79 are not supported by Cats.
 Please use Blender 2.79 or later.
 ",,"
 
-2.79 이전의 블렌더 버전은 Cats에서 지원하지 않습니다. 
+2.79 이전의 블렌더 버전은 Cats에서 지원하지 않습니다.
 Blender 2.79 버전 이상을 사용하세요.
 "
 Main.error.beta2.80,"
@@ -146,7 +146,7 @@ EyeTrackingPanel.error.wrongNameArm3,      (currently ',      (現在は ',     
 EyeTrackingPanel.error.wrongNameBody1,The mesh containing the eyes has to be,アイトラッキングが機能するには,눈들을 포함한 메쉬는 반드시
 EyeTrackingPanel.error.wrongNameBody2,      named 'Body' for Eye Tracking to work!,      目を含むメッシュに'Body'という名前を付ける必要があります!,      눈 추적(Eye Tracking)을 위해 'Body'로 이름을 지어야 합니다.
 EyeTrackingPanel.error.wrongNameBody3,      (currently ',      (現在は ',      (현재로서는 '
-EyeTrackingPanel.warn.assignEyes1,Don't forget to assign 'LeftEye' and 'RightEye','左目'と'右目' を割り当てることを忘れないでください。,유니티에서 'LeftEye'와 'RightEye'를 
+EyeTrackingPanel.warn.assignEyes1,Don't forget to assign 'LeftEye' and 'RightEye','左目'と'右目' を割り当てることを忘れないでください。,유니티에서 'LeftEye'와 'RightEye'를
 EyeTrackingPanel.warn.assignEyes2,      to the eyes in Unity!,      ユニティの目に,      적용하는 것을 잊지 마세요!
 VisemePanel.label,Visemes,バイセム,립싱크(Visemes)
 VisemePanel.error.noMesh,No meshes found!,メッシュが見つかりません!,메쉬가 발견되지 않음!
@@ -180,6 +180,11 @@ BakePanel.alphalabel,Alpha:,,
 BakePanel.transparencywarning,Transparency isn't currently selected!,,현재 투명도가 선택되지 않았습니다!
 BakePanel.smoothnesswarning,Smoothness isn't currently selected!,,현재 부드러움이 선택되지 않았습니다!
 BakePanel.doublepackwarning,Smoothness packed in two places!,,두군데에 부드러움이 설정되었습니다!
+ScalingPanel.label,Scaling,,
+ScalingPanel.imscaleDisabled1,Immersive Scaler is not enabled!,,
+ScalingPanel.imscaleDisabled2,Enable it in your user preferences:,,
+ScalingPanel.imscaleNotInstalled1,Immersive Scaler is not installed!:,,
+ScalingPanel.imscaleNotInstalled2,Download and install it manually:,,
 UpdaterPanel.label,Settings & Updates,設定と更新,세팅 & 업데이트
 UpdaterPanel.name,Settings:,設定:,세팅:
 UpdaterPanel.requireRestart1,Restart required.,再起動が必要.,재시작이 필요합니다.
@@ -228,7 +233,7 @@ FixArmature.cantFix1,Looks like you found a model which Cats could not fix!,,Cat
 FixArmature.cantFix2,If this is a non modified model we would love to make it compatible.,,이것이 수정되지 않은 모델이라면 우리는 호환되도록 만들고 싶습니다.
 FixArmature.cantFix3,"Report it to us in the forum or in our discord, links can be found in the Credits panel.",,포럼이나 디스코드에서 우리에게 신고해주세요. 링크는 크레딧 패널에 있습니다.
 FixArmature.notParent," is not parented at all, this will cause problems!",," 부모설정이 전혀 안됐다면, 이로 인해 문제가 발생할 수 있습니다!"
-FixArmature.notParentTo1, is not parented to ,, 가 
+FixArmature.notParentTo1, is not parented to ,, 가
 FixArmature.notParentTo2,", this will cause problems!",,"의 부모로 설정돼지 않았다면, 이로 인해 문제가 발생할 수 있습니다!"
 StartPoseMode.label,Start Pose Mode,ポーズモードを開始,포즈모드 시작
 StartPoseMode.desc,"Starts the pose mode.
@@ -453,6 +458,15 @@ InstallShotariya.error.version3,Please download and install it manually:,,
 ShotariyaButton.label,Download Material Combiner,マテリアルコンバイナーをダウンロード,매테리얼 통합기 다운로드
 ShotariyaButton.URL,https://vrcat.club/threads/material-combiner-blender-addon-1-1-3.2255/,,
 ShotariyaButton.success,Material Combiner link opened,,
+ImmersiveScalerButton.URL,https://github.com/triazo/immersive_scaler/releases/latest,,
+ImmersiveScalerButton.success,Immersive Scaler link opened,,
+ImmersiveScalerHelpButton.URL,https://github.com/triazo/immersive_scaler,,
+ImmersiveScalerHelpButton.label,Immersive Scaling,,
+ImmersiveScalerHelpButton.desc,Open guide for Immersive Scaler,,
+ImmersiveScalerHelpButton.success,Immersive Scaler Readme opened,,
+EnableIMScale.label,Enable Immersive Scaler,,
+EnableIMScale.desc,Enable Immersive Scaler,,
+EnableIMScale.success,Enabled Immersive Scaler!,,
 BoneMergeButton.label,Merge Bones,ボーンをマージする,뼈 통합
 BoneMergeButton.desc,"Merges the given percentage of bones together.
 This is useful to reduce the amount of bones used by Dynamic Bones.",,
@@ -555,8 +569,8 @@ Supported types:
 - XNALara: .xps/.mesh/.ascii
 - Source: .smd/.qc
 - VRM: .vrm
-- FBX .fbx 
-- DAE: .dae 
+- FBX .fbx
+- DAE: .dae
 - ZIP: .zip",,
 ImportAnyModel.desc2.8,"Import a model of any supported type.
 
@@ -566,7 +580,7 @@ Supported types:
 - Source: .smd/.qc/.vta/.dmx
 - VRM: .vrm
 - FBX: .fbx
-- DAE: .dae 
+- DAE: .dae
 - ZIP: .zip",,
 ImportAnyModel.importantInfo.label,IMPORTANT INFO (hover here),重要な情報(ここにホバー),
 ImportAnyModel.importantInfo.desc,"If you want to modify the import settings, use the button next to the Import button.

--- a/resources/translations.csv
+++ b/resources/translations.csv
@@ -183,6 +183,7 @@ BakePanel.doublepackwarning,Smoothness packed in two places!,,두군데에 부�
 ScalingPanel.label,Scaling,,
 ScalingPanel.imscaleDisabled1,Immersive Scaler is not enabled!,,
 ScalingPanel.imscaleDisabled2,Enable it in your user preferences:,,
+ScalingPanel.imscaleOldVersion1,Immersive Scaler is not installed!,,
 ScalingPanel.imscaleNotInstalled1,Immersive Scaler is not installed!,,
 ScalingPanel.imscaleNotInstalled2,Download and install it manually:,,
 UpdaterPanel.label,Settings & Updates,設定と更新,세팅 & 업데이트

--- a/resources/translations.csv
+++ b/resources/translations.csv
@@ -183,7 +183,7 @@ BakePanel.doublepackwarning,Smoothness packed in two places!,,두군데에 부�
 ScalingPanel.label,Scaling,,
 ScalingPanel.imscaleDisabled1,Immersive Scaler is not enabled!,,
 ScalingPanel.imscaleDisabled2,Enable it in your user preferences:,,
-ScalingPanel.imscaleNotInstalled1,Immersive Scaler is not installed!:,,
+ScalingPanel.imscaleNotInstalled1,Immersive Scaler is not installed!,,
 ScalingPanel.imscaleNotInstalled2,Download and install it manually:,,
 UpdaterPanel.label,Settings & Updates,設定と更新,세팅 & 업데이트
 UpdaterPanel.name,Settings:,設定:,세팅:
@@ -460,8 +460,10 @@ ShotariyaButton.URL,https://vrcat.club/threads/material-combiner-blender-addon-1
 ShotariyaButton.success,Material Combiner link opened,,
 ImmersiveScalerButton.URL,https://github.com/triazo/immersive_scaler/releases/latest,,
 ImmersiveScalerButton.success,Immersive Scaler link opened,,
+ImmersiveScalerButton.label,Download Immersive Scaler,,
+ImmersiveScalerButton.desc,Open latest Immersive Scaler release,,
 ImmersiveScalerHelpButton.URL,https://github.com/triazo/immersive_scaler,,
-ImmersiveScalerHelpButton.label,Immersive Scaling,,
+ImmersiveScalerHelpButton.label,Download Immersive Scaler,,
 ImmersiveScalerHelpButton.desc,Open guide for Immersive Scaler,,
 ImmersiveScalerHelpButton.success,Immersive Scaler Readme opened,,
 EnableIMScale.label,Enable Immersive Scaler,,

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -19,6 +19,7 @@ if "bpy" not in locals():
     from . import rootbone
     from . import bake
     from . import settings
+    from . import scale
     from . import shapekey
     from . import supporter
     from . import translate
@@ -45,6 +46,7 @@ else:
     importlib.reload(rootbone)
     importlib.reload(bake)
     importlib.reload(settings)
+    importlib.reload(scale)
     importlib.reload(shapekey)
     importlib.reload(supporter)
     importlib.reload(translate)

--- a/tools/scale.py
+++ b/tools/scale.py
@@ -1,0 +1,69 @@
+###
+# Rather than being a full implementation, this links pulls from
+# immersive scaler upstream so that updates are simply worked in.
+#
+# Code largely taken from the material combiner integration.
+##
+
+# Operator to enable the immersive scaler after it's installed
+@register_wrap
+class EnableSMC(bpy.types.Operator):
+    bl_idname = 'cats_scale.enable_imscale'
+    bl_label = t('EnableIMScale.label')
+    bl_description = t('EnableIMScale.desc')
+    bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
+
+    def execute(self, context):
+        # disable all wrong versions
+        for mod in addon_utils.modules():
+            if mod.bl_info['name'] == "Immersive Scaler":
+                if mod.bl_info['version'] < (0, 2, 7) and addon_utils.check(mod.__name__)[0]:
+                    try:
+                        if Common.version_2_79_or_older():
+                            bpy.ops.wm.addon_disable(module=mod.__name__)
+                        else:
+                            bpy.ops.preferences.addon_disable(module=mod.__name__)
+                    except:
+                        pass
+                    continue
+
+        # then enable correct version
+        for mod in addon_utils.modules():
+            if mod.bl_info['name'] == "Immersive Scaler":
+                if mod.bl_info['version'] < (0, 2, 7):
+                    continue
+                if not addon_utils.check(mod.__name__)[0]:
+                    if Common.version_2_79_or_older():
+                        bpy.ops.wm.addon_enable(module=mod.__name__)
+                    else:
+                        bpy.ops.preferences.addon_enable(module=mod.__name__)
+                    break
+        self.report({'INFO'}, t('EnableIMScale.success'))
+        return {'FINISHED'}
+
+
+# Link to install
+@register_wrap
+class ImmersiveScalerButton(bpy.types.Operator):
+    bl_idname = 'imscale.download_immersive_scaler'
+    bl_label = t('')
+    bl_options = {'INTERNAL'}
+
+    def execute(self, context):
+        webbrowser.open(t('ImmersiveScalerButton.URL'))
+
+        self.report({'INFO'}, 'ImmersiveScalerButton.success')
+        return {'FINISHED'}
+
+# Link to readme for help
+@register_wrap
+class ImmersiveScalerHelpButton(bpy.types.Operator):
+    bl_idname = 'imscale.help'
+    bl_label = t('ImmersiveScalerHelpButton.label')
+    bl_description = t('ImmersiveScalerHelpButton.desc')
+    bl_options = {'INTERNAL'}
+
+    def execute(self, context):
+        webbrowser.open(t('ImmersiveScalerHelpButton.URL'))
+        self.report({'INFO'}, t('ImmersiveScalerHelpButton.success'))
+        return {'FINISHED'}

--- a/tools/scale.py
+++ b/tools/scale.py
@@ -5,9 +5,17 @@
 # Code largely taken from the material combiner integration.
 ##
 
+import bpy
+import webbrowser
+import addon_utils
+
+from . import common as Common
+from .register import register_wrap
+from .translations import t
+
 # Operator to enable the immersive scaler after it's installed
 @register_wrap
-class EnableSMC(bpy.types.Operator):
+class EnableIMScale(bpy.types.Operator):
     bl_idname = 'cats_scale.enable_imscale'
     bl_label = t('EnableIMScale.label')
     bl_description = t('EnableIMScale.desc')
@@ -46,7 +54,8 @@ class EnableSMC(bpy.types.Operator):
 @register_wrap
 class ImmersiveScalerButton(bpy.types.Operator):
     bl_idname = 'imscale.download_immersive_scaler'
-    bl_label = t('')
+    bl_label = t('ImmersiveScalerButton.label')
+    bl_description = t('ImmersiveScalerButton.desc')
     bl_options = {'INTERNAL'}
 
     def execute(self, context):
@@ -65,5 +74,6 @@ class ImmersiveScalerHelpButton(bpy.types.Operator):
 
     def execute(self, context):
         webbrowser.open(t('ImmersiveScalerHelpButton.URL'))
+
         self.report({'INFO'}, t('ImmersiveScalerHelpButton.success'))
         return {'FINISHED'}

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -11,6 +11,7 @@ if "bpy" not in locals():
     from . import bone_root
     from . import optimization
     from . import bake
+    from . import scale
     from . import copy_protection
     from . import settings_updates
     from . import supporter
@@ -28,6 +29,7 @@ else:
     importlib.reload(bone_root)
     importlib.reload(optimization)
     importlib.reload(bake)
+    importlib.reload(scale)
     importlib.reload(copy_protection)
     importlib.reload(settings_updates)
     importlib.reload(supporter)

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -5,13 +5,13 @@ if "bpy" not in locals():
     from . import armature
     from . import manual
     from . import custom
+    from . import scale
     from . import decimation
     from . import eye_tracking
     from . import visemes
     from . import bone_root
     from . import optimization
     from . import bake
-    from . import scale
     from . import copy_protection
     from . import settings_updates
     from . import supporter
@@ -23,13 +23,13 @@ else:
     importlib.reload(armature)
     importlib.reload(manual)
     importlib.reload(custom)
+    importlib.reload(scale)
     importlib.reload(decimation)
     importlib.reload(eye_tracking)
     importlib.reload(visemes)
     importlib.reload(bone_root)
     importlib.reload(optimization)
     importlib.reload(bake)
-    importlib.reload(scale)
     importlib.reload(copy_protection)
     importlib.reload(settings_updates)
     importlib.reload(supporter)

--- a/ui/scale.py
+++ b/ui/scale.py
@@ -48,7 +48,10 @@ class ScalingPanel(ToolPanel, bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
 
-        row.operator(Scaler
+        box = layout.box()
+        col = box.column(align=True)
+        row = col.row(align=True)
+        row.operator(Scaler.ImmersiveScalerHelpButton.bl_idname, icon='QUESTION')
 
         # Installed but disabled
         if imscale_is_disabled:
@@ -76,13 +79,13 @@ class ScalingPanel(ToolPanel, bpy.types.Panel):
         if not draw_imscale_ui:
             box = layout.box()
             col = box.column(align=True)
-            row = row.col(align=True)
+            row = col.row(align=True)
 
             row.scale_y = 0.75
             row.label(text=t('ScalingPanel.imscaleNotInstalled1'))
             row = col.row(align=True)
             row.scale_y = 0.75
-            row.label(text=t('ScalingPanel.imscaleDisabled2'))
+            row.label(text=t('ScalingPanel.imscaleNotInstalled2'))
             col.separator()
             row = col.row(align=True)
             row.operator(Scaler.ImmersiveScalerButton.bl_idname, icon='CHECKBOX_HLT')

--- a/ui/scale.py
+++ b/ui/scale.py
@@ -1,0 +1,97 @@
+# (global-set-key (kbd "C-c m") (lambda () (interactive) (shell-command "zip -r ../../cats-dev.zip ../../cats-blender-plugin")))
+
+import bpy
+import addon_utils
+from importlib import import_module
+
+from .main import ToolPanel
+from ..tools import scale as Scaler
+
+from ..tools.translations import t
+from ..tools.register import register_wrap
+
+draw_imscale_ui = None
+imscale_is_disabled = False
+old_imscale_version = False
+
+def check_for_imscale():
+    global draw_imscale_ui, old_imscale_version, imscale_is_disabled
+
+    draw_imscale_ui = None
+
+    for mod in addon_utils.modules():
+        if mod.bl_info['name'] == "Immersive Scaler":
+            # print(mod.__name__, mod.bl_info['version'])
+            # print(addon_utils.check(mod.__name__))
+            if mod.bl_info['version'] < (0, 2, 7):
+                old_imscale_version = True
+                # print('TOO OLD!')
+                continue
+            if not addon_utils.check(mod.__name__)[0]:
+                imscale_is_disabled = True
+                # print('DISABLED!')
+                continue
+
+            # print('FOUND!')
+            old_imscale_version = False
+            imscale_is_disabled = False
+            draw_imscale_ui = getattr(import_module(mod.__name__ + '.ui'), 'draw_ui')
+
+            break
+
+@register_wrap
+class ScalingPanel(ToolPanel, bpy.types.Panel):
+    bl_idname = 'VIEW3D_PT_scale_v1'
+    bl_label = t('ScalingPanel.label')
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        layout = self.layout
+
+        row.operator(Scaler
+
+        # Installed but disabled
+        if imscale_is_disabled:
+            box = layout.box()
+            col = box.column(align=True)
+            row = col.row(align=True)
+
+            row.scale_y = 0.75
+            row.label(text=t('ScalingPanel.imscaleDisabled1'))
+            row = col.row(align=True)
+            row.scale_y = 0.75
+            row.label(text=t('ScalingPanel.imscaleDisabled2'))
+            col.separator()
+            row = col.row(align=True)
+            row.operator(Scaler.EnableIMScale.bl_idname, icon='CHECKBOX_HLT')
+            check_for_imscale()
+            return None
+
+        if old_imscale_version:
+            print("Old Immersive Scaler Version!!")
+            check_for_imscale()
+            return None
+
+        # Imscale is not found
+        if not draw_imscale_ui:
+            box = layout.box()
+            col = box.column(align=True)
+            row = row.col(align=True)
+
+            row.scale_y = 0.75
+            row.label(text=t('ScalingPanel.imscaleNotInstalled1'))
+            row = col.row(align=True)
+            row.scale_y = 0.75
+            row.label(text=t('ScalingPanel.imscaleDisabled2'))
+            col.separator()
+            row = col.row(align=True)
+            row.operator(Scaler.ImmersiveScalerButton.bl_idname, icon='CHECKBOX_HLT')
+            check_for_imscale()
+            return None
+
+            check_for_imscale()
+            return None
+
+
+        # imscale = __import__('immersive_scaler')
+        return draw_imscale_ui(context, layout)

--- a/ui/scale.py
+++ b/ui/scale.py
@@ -70,8 +70,22 @@ class ScalingPanel(ToolPanel, bpy.types.Panel):
             check_for_imscale()
             return None
 
+        # Currently, instructions for an old version are the same as
+        # it not being installed - a manual install either way.
         if old_imscale_version:
-            print("Old Immersive Scaler Version!!")
+            box = layout.box()
+            col = box.column(align=True)
+            row = col.row(align=True)
+
+            row.scale_y = 0.75
+            row.label(text=t('ScalingPanel.imscaleOldVersion1'))
+            row = col.row(align=True)
+            row.scale_y = 0.75
+            row.label(text=t('ScalingPanel.imscaleNotInstalled2'))
+            col.separator()
+            row = col.row(align=True)
+            row.operator(Scaler.ImmersiveScalerButton.bl_idname, icon='CHECKBOX_HLT')
+
             check_for_imscale()
             return None
 


### PR DESCRIPTION
I tried to more or less copy the mechanics of how material combiner is integrated, it depends on triazo/immersive_scaler@8ef53c64, the interface is currently just one exposed function so I should be able to keep updating the scaler without code change on the cats side.

I couldn't figure a good spot to put it in any existing panel so I made a new one - Scaling - below the Bake panel for now. If you can see a link that I can't or can think of a better spot I can move it. Same thing to the installation method, I have it pointing to the latest github tag right now, but am open to change.

Current known bugs
- If you disable immersive scaler after starting with it enabled, the ui drawing function is still found by cats but the operators aren't, leaving most of the ui in the scaling tab, but it isn't the showing the alternate ui to enable the plugin.
- Needs translations to non-english for some things. Applies to immersive scaler itself too but none of that should be code here.
