### PR TITLE
Bake Fixes

### DIFF
--- a/extentions.py
+++ b/extentions.py
@@ -212,7 +212,9 @@ def register():
         precision=2,
         subtype='FACTOR'
     )
-
+    
+    
+    # Bake
     Scene.bake_animation_weighting = BoolProperty(
         name=t('Scene.decimation_animation_weighting.label'),
         description=t('Scene.decimation_animation_weighting.desc'),
@@ -273,8 +275,7 @@ def register():
         description="Create 'Disable' shapekeys for all but the largest mesh, that cause it to shrink to nothing. Lets you keep toggleable props, without the need for additional meshes.",
         default=False
     )
-
-    # Bake
+    
     Scene.bake_resolution = IntProperty(
         name=t('Scene.bake_resolution.label'),
         description=t('Scene.bake_resolution.desc'),
@@ -485,8 +486,18 @@ def register():
         description="Optimizes solid materials by making a small area for them. AO pass will nullify",
         default=True
     )
-
-
+    
+    Scene.bake_unwrap_angle = FloatProperty(
+        name="Unwrap Angle",
+        description="The angle Reproject uses when unwrapping. Larger angles yield less islands but more stretching and smaller does opposite",
+        default=66.0,
+        min=0.1,
+        max=89.9,
+        step=0.1,
+        precision=1
+    )
+    
+    
     Scene.selection_mode = EnumProperty(
         name=t('Scene.selection_mode.label'),
         description=t('Scene.selection_mode.desc'),

--- a/extentions.py
+++ b/extentions.py
@@ -479,6 +479,12 @@ def register():
         precision=2,
         subtype='FACTOR'
     )
+    
+    Scene.bake_optimize_solid_materials = BoolProperty(
+        name="Optimize Solid Materials",
+        description="Optimizes solid materials by making a small area for them. AO pass will nullify",
+        default=True
+    )
 
 
     Scene.selection_mode = EnumProperty(

--- a/tools/bake.py
+++ b/tools/bake.py
@@ -659,8 +659,8 @@ class BakeButton(bpy.types.Operator):
                                         
                                         
                                         #assign to image so it's baked
-                                        node_image.image.generated_color = node.inputs["Roughness"].default_value
-                                        smoothness_color = node.inputs["Roughness"].default_value
+                                        node_image.image.generated_color = [node.inputs["Roughness"].default_value]*4
+                                        smoothness_color = [node.inputs["Roughness"].default_value]*4
                                         node_image.image.file_format = 'PNG'
                                         material.node_tree.links.new(node_image.outputs['Color'], node_prinipled.inputs['Roughness'])
                                     else:
@@ -678,8 +678,8 @@ class BakeButton(bpy.types.Operator):
                                         
                                         
                                         #assign to image so it's baked
-                                        node_image.image.generated_color = node.inputs["Metallic"].default_value
-                                        metallic_color = node.inputs["Metallic"].default_value
+                                        node_image.image.generated_color = [node.inputs["Metallic"].default_value]*4
+                                        metallic_color = [node.inputs["Metallic"].default_value]*4
                                         node_image.image.file_format = 'PNG'
                                         material.node_tree.links.new(node_image.outputs['Color'], node_prinipled.inputs['Metallic'])
                                     else:

--- a/ui/bake.py
+++ b/ui/bake.py
@@ -68,13 +68,14 @@ class BakePanel(ToolPanel, bpy.types.Panel):
             row.prop(context.scene, 'bake_prioritize_face', expand=True)
             row = col.row(align=True)
             row.separator()
-            row.prop(context.scene, 'bake_optimize_solid_materials', expand=True)
+            if context.scene.bake_uv_overlap_correction != "NONE" and (not context.scene.bake_pass_ao) and (not context.scene.bake_use_decimation) and (not context.scene.bake_pass_normal):
+                row.prop(context.scene, 'bake_optimize_solid_materials', expand=True)
             if context.scene.bake_prioritize_face:
                 armature = Common.get_armature()
                 row = col.row(align=True)
                 row.separator()
                 row.prop(context.scene, 'bake_face_scale', expand=True)
-
+                    
                 if armature is None or len(Common.get_bones(names=['Head', 'head'], armature_name=armature.name, check_list=True)) == 0:
                     row = col.row(align=True)
                     row.separator()
@@ -83,6 +84,10 @@ class BakePanel(ToolPanel, bpy.types.Panel):
             row.separator()
             row.label(text=t('BakePanel.overlapfixlabel'))
             row.prop(context.scene, 'bake_uv_overlap_correction', expand=True)
+            if context.scene.bake_uv_overlap_correction == "REPROJECT":
+                row = col.row(align=True)
+                row.separator()
+                row.prop(context.scene, 'bake_unwrap_angle', expand=True)
         row = col.row(align=True)
         row.prop(context.scene, 'bake_ignore_hidden', expand=True)
         row = col.row(align=True)

--- a/ui/bake.py
+++ b/ui/bake.py
@@ -66,6 +66,9 @@ class BakePanel(ToolPanel, bpy.types.Panel):
             row = col.row(align=True)
             row.separator()
             row.prop(context.scene, 'bake_prioritize_face', expand=True)
+            row = col.row(align=True)
+            row.separator()
+            row.prop(context.scene, 'bake_optimize_solid_materials', expand=True)
             if context.scene.bake_prioritize_face:
                 armature = Common.get_armature()
                 row = col.row(align=True)


### PR DESCRIPTION
- Added auto generation of images for solid materials upon bake. Also checks if materials are solid for future implementation of putting solid materials into their own small section of the bake texture for better optimization
- Added commented code that is so close to working, just has no effect and don't know why. It should put materials into their own part of the UV and scale the rest of the UV out the way
- improved margin calculation for very close islands, improving utilization of space by 50%