### PR TITLE
Much Needed UI Update For Long Enum List Drop Downs

### DIFF
--- a/ui/eye_tracking.py
+++ b/ui/eye_tracking.py
@@ -7,6 +7,140 @@ from ..tools import eyetracking as Eyetracking
 from ..tools.register import register_wrap
 from ..tools.translations import t
 
+
+@register_wrap
+class SearchMenuOperatorBoneHead(bpy.types.Operator):
+    bl_description = t('Scene.head.desc')
+    bl_idname = "scene.search_menu_head"
+    bl_label = ""
+    bl_property = "my_enum"
+
+    my_enum: bpy.props.EnumProperty(name="shapekeys", items=Common.get_bones_head)
+    
+    def execute(self, context):
+        context.scene.head = self.my_enum
+        print(context.scene.head)
+        return {'FINISHED'}
+    
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+
+@register_wrap
+class SearchMenuOperatorBoneEyeLeft(bpy.types.Operator):
+    bl_description = t('Scene.eye_left.desc')
+    bl_idname = "scene.search_menu_eye_left"
+    bl_label = ""
+    bl_property = "my_enum"
+
+    my_enum: bpy.props.EnumProperty(name="shapekeys", items=Common.get_bones_eye_l)
+    
+    def execute(self, context):
+        context.scene.eye_left = self.my_enum
+        print(context.scene.eye_left)
+        return {'FINISHED'}
+    
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+
+@register_wrap
+class SearchMenuOperatorBoneEyeRight(bpy.types.Operator):
+    bl_description = t('Scene.eye_right.desc')
+    bl_idname = "scene.search_menu_eye_right"
+    bl_label = ""
+    bl_property = "my_enum"
+
+    my_enum: bpy.props.EnumProperty(name="shapekeys", items=Common.get_bones_eye_r)
+    
+    def execute(self, context):
+        context.scene.eye_right = self.my_enum
+        print(context.scene.eye_right)
+        return {'FINISHED'}
+    
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+    
+@register_wrap
+class SearchMenuOperatorShapekeyWinkLeft(bpy.types.Operator):
+    bl_description = t('Scene.wink_left.desc')
+    bl_idname = "scene.search_menu_wink_left"
+    bl_label = ""
+    bl_property = "my_enum"
+
+    my_enum: bpy.props.EnumProperty(name="shapekeys", items=Common.get_shapekeys_eye_blink_l)
+    
+    def execute(self, context):
+        context.scene.wink_left = self.my_enum
+        print(context.scene.wink_left)
+        return {'FINISHED'}
+    
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+
+@register_wrap
+class SearchMenuOperatorShapekeyWinkRight(bpy.types.Operator):
+    bl_description = t('Scene.wink_right.desc')
+    bl_idname = "scene.search_menu_wink_right"
+    bl_label = ""
+    bl_property = "my_enum"
+
+    my_enum: bpy.props.EnumProperty(name="shapekeys", items=Common.get_shapekeys_eye_blink_r)
+    
+    def execute(self, context):
+        context.scene.wink_right = self.my_enum
+        print(context.scene.wink_right)
+        return {'FINISHED'}
+    
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+
+@register_wrap
+class SearchMenuOperatorShapekeyLowerLidLeft(bpy.types.Operator):
+    bl_description = t('Scene.lowerlid_left.desc')
+    bl_idname = "scene.search_menu_lowerlid_left"
+    bl_label = ""
+    bl_property = "my_enum"
+
+    my_enum: bpy.props.EnumProperty(name="shapekeys", items=Common.get_shapekeys_eye_low_l)
+    
+    def execute(self, context):
+        context.scene.lowerlid_left = self.my_enum
+        print(context.scene.lowerlid_left)
+        return {'FINISHED'}
+    
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+
+@register_wrap
+class SearchMenuOperatorShapekeyLowerLidRight(bpy.types.Operator):
+    bl_description = t('Scene.lowerlid_right.desc')
+    bl_idname = "scene.search_menu_lowerlid_right"
+    bl_label = ""
+    bl_property = "my_enum"
+
+    my_enum: bpy.props.EnumProperty(name="shapekeys", items=Common.get_shapekeys_eye_low_r)
+    
+    def execute(self, context):
+        context.scene.lowerlid_right = self.my_enum
+        print(context.scene.lowerlid_right)
+        return {'FINISHED'}
+    
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+    
 @register_wrap
 class EyeTrackingPanel(ToolPanel, bpy.types.Panel):
     bl_idname = 'VIEW3D_PT_eye_v3'
@@ -38,39 +172,47 @@ class EyeTrackingPanel(ToolPanel, bpy.types.Panel):
             col.separator()
             row = col.row(align=True)
             row.scale_y = 1.1
-            row.prop(context.scene, 'head', icon='BONE_DATA')
+            row.label(text=t('Scene.head.label')+":")
+            row.operator(SearchMenuOperatorBoneHead.bl_idname, text = context.scene.head, icon='BONE_DATA')
             row = col.row(align=True)
             row.scale_y = 1.1
             if context.scene.disable_eye_movement:
                 row.active = False
-            row.prop(context.scene, 'eye_left', icon='BONE_DATA')
+            row.label(text=t('Scene.eye_left.label')+":")
+            row.operator(SearchMenuOperatorBoneEyeLeft.bl_idname, text = context.scene.eye_left, icon='BONE_DATA')
             row = col.row(align=True)
             row.scale_y = 1.1
             if context.scene.disable_eye_movement:
                 row.active = False
-            row.prop(context.scene, 'eye_right', icon='BONE_DATA')
+            row.label(text=t('Scene.eye_right.label')+":")
+            row.operator(SearchMenuOperatorBoneEyeRight.bl_idname, text = context.scene.eye_right, icon='BONE_DATA')
 
             col.separator()
             row = col.row(align=True)
             row.scale_y = 1.1
             if context.scene.disable_eye_blinking:
                 row.active = False
-            row.prop(context.scene, 'wink_left', icon='SHAPEKEY_DATA')
+            row.label(text=t('Scene.wink_left.label')+":")
+            row.operator(SearchMenuOperatorShapekeyWinkLeft.bl_idname, text = context.scene.wink_left, icon='SHAPEKEY_DATA')
+            #row.prop(context.scene, 'wink_left', icon='SHAPEKEY_DATA')
             row = col.row(align=True)
             row.scale_y = 1.1
             if context.scene.disable_eye_blinking:
                 row.active = False
-            row.prop(context.scene, 'wink_right', icon='SHAPEKEY_DATA')
+            row.label(text=t('Scene.wink_right.label')+":")
+            row.operator(SearchMenuOperatorShapekeyWinkRight.bl_idname, text = context.scene.wink_right, icon='SHAPEKEY_DATA')
             row = col.row(align=True)
             row.scale_y = 1.1
             if context.scene.disable_eye_blinking:
                 row.active = False
-            row.prop(context.scene, 'lowerlid_left', icon='SHAPEKEY_DATA')
+            row.label(text=t('Scene.lowerlid_left.label')+":")
+            row.operator(SearchMenuOperatorShapekeyLowerLidLeft.bl_idname, text = context.scene.lowerlid_left, icon='SHAPEKEY_DATA')
             row = col.row(align=True)
             row.scale_y = 1.1
             if context.scene.disable_eye_blinking:
                 row.active = False
-            row.prop(context.scene, 'lowerlid_right', icon='SHAPEKEY_DATA')
+            row.label(text=t('Scene.lowerlid_right.label')+":")
+            row.operator(SearchMenuOperatorShapekeyLowerLidRight.bl_idname, text = context.scene.lowerlid_right, icon='SHAPEKEY_DATA')
 
             col.separator()
             row = col.row(align=True)

--- a/ui/visemes.py
+++ b/ui/visemes.py
@@ -9,6 +9,63 @@ from ..tools.translations import t
 
 
 @register_wrap
+class SearchMenuOperatorMouthA(bpy.types.Operator):
+    bl_description = t('Scene.mouth_a.desc')
+    bl_idname = "scene.search_menu_mouth_a"
+    bl_label = ""
+    bl_property = "my_enum"
+
+    my_enum: bpy.props.EnumProperty(name="shapekeys", description=t('Scene.mouth_a.desc'), items=Common.get_shapekeys_mouth_ah) #default, change after making operator in UI like shown below.7
+
+    def execute(self, context):
+        context.scene.mouth_a = self.my_enum
+        print(context.scene.mouth_a)
+        return {'FINISHED'}
+    
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+
+@register_wrap
+class SearchMenuOperatorMouthO(bpy.types.Operator):
+    bl_description = t('Scene.mouth_o.desc')
+    bl_idname = "scene.search_menu_mouth_o"
+    bl_label = ""
+    bl_property = "my_enum"
+
+    my_enum: bpy.props.EnumProperty(name="shapekeys", description=t('Scene.mouth_o.desc'), items=Common.get_shapekeys_mouth_oh) #default, change after making operator in UI like shown below.7
+
+    def execute(self, context):
+        context.scene.mouth_o = self.my_enum
+        print(context.scene.mouth_o)
+        return {'FINISHED'}
+    
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+
+@register_wrap
+class SearchMenuOperatorMouthCH(bpy.types.Operator):
+    bl_description = t('Scene.mouth_ch.desc')
+    bl_idname = "scene.search_menu_mouth_ch"
+    bl_label = ""
+    bl_property = "my_enum"
+
+    my_enum: bpy.props.EnumProperty(name="shapekeys", description=t('Scene.mouth_ch.desc'), items=Common.get_shapekeys_mouth_ch) #default, change after making operator in UI like shown below.7
+
+    def execute(self, context):
+        context.scene.mouth_ch = self.my_enum
+        print(context.scene.mouth_ch)
+        return {'FINISHED'}
+    
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+
+@register_wrap
 class VisemePanel(ToolPanel, bpy.types.Panel):
     bl_idname = 'VIEW3D_PT_viseme_v3'
     bl_label = t('VisemePanel.label')
@@ -33,13 +90,16 @@ class VisemePanel(ToolPanel, bpy.types.Panel):
 
         row = col.row(align=True)
         row.scale_y = 1.1
-        row.prop(context.scene, 'mouth_a', icon='SHAPEKEY_DATA')
+        row.label(text=t('Scene.mouth_a.label')+":")
+        row.operator(SearchMenuOperatorMouthA.bl_idname, text = context.scene.mouth_a, icon='SHAPEKEY_DATA')
         row = col.row(align=True)
         row.scale_y = 1.1
-        row.prop(context.scene, 'mouth_o', icon='SHAPEKEY_DATA')
+        row.label(text=t('Scene.mouth_o.label')+":")
+        row.operator(SearchMenuOperatorMouthO.bl_idname, text = context.scene.mouth_o, icon='SHAPEKEY_DATA')
         row = col.row(align=True)
         row.scale_y = 1.1
-        row.prop(context.scene, 'mouth_ch', icon='SHAPEKEY_DATA')
+        row.label(text=t('Scene.mouth_ch.label')+":")
+        row.operator(SearchMenuOperatorMouthCH.bl_idname, text = context.scene.mouth_ch, icon='SHAPEKEY_DATA')
 
         col.separator()
         row = col.row(align=True)


### PR DESCRIPTION
Fixed issues with people having problems with scrolling through large numbers of bones/shapekeys on the eye tracking and viseme panels. The shapekey and bone menus are now replaced with buttons that bring up an Enum search like the f3/spacebar menu and then reflect the name of the item selected.