### PR TITLE
upperchest info correction

### DIFF
--- a/extentions.py
+++ b/extentions.py
@@ -28,7 +28,7 @@ def register():
     Scene.keep_upper_chest = BoolProperty(
         name=t('Scene.keep_upper_chest.label'),
         description=t('Scene.keep_upper_chest.desc'),
-        default=False
+        default=True
     )
 
     Scene.combine_mats = BoolProperty(

--- a/resources/translations.csv
+++ b/resources/translations.csv
@@ -762,7 +762,7 @@ Scene.zip_content.desc,Select the model you want to import,,불러올 모델을 
 Scene.keep_upper_chest.label,Keep Upper Chest,上部の胸の骨を保つ,Upper Chest 보존
 Scene.keep_upper_chest.desc,"VRChat now partially supports the Upper Chest bone, so deleting it is no longer necessary.
 
-WARNING: Currently this breaks Eye Tracking, so don't check this if you want Eye Tracking",,"VRChat은 이제 상단 가슴(Upper Chest) 본을 부분적으로 지원하므로 더 이상 삭제할 필요가 없습니다.
+Uncheck this if you are going to use the legacy SDK2 avatar system. Most people can leave this on.",,"VRChat은 이제 상단 가슴(Upper Chest) 본을 부분적으로 지원하므로 더 이상 삭제할 필요가 없습니다.
 
 경고: 현재 이것은 눈 추적(Eye Tracking)을 망치기 때문에, 눈 추적을 원한다면 이것을 체크하지 말아주세요."
 Scene.combine_mats.label,Combine Same Materials,同じマテリアルを組み合わせる,동일한 매테리얼 결합


### PR DESCRIPTION
Upper chest works fine in SDK3. SDK2 has been deprecated and should no longer be considered the main target for avatar creators.

Upper chest improves posing, so pushing authors to include that bone and to map it is important!