### PR TITLE
Added option to disable Shape Key Cleanup on Armature Merge

### DIFF
--- a/extentions.py
+++ b/extentions.py
@@ -175,6 +175,12 @@ def register():
         description=t('Scene.merge_armatures_remove_zero_weight_bones.desc'),
         default=True
     )
+    
+    Scene.merge_armatures_cleanup_shape_keys = BoolProperty(
+        name=t('Scene.merge_armatures_cleanup_shape_keys.label'),
+        description=t('Scene.merge_armatures_cleanup_shape_keys.desc'),
+        default=True
+    )
 
     # Decimation
     Scene.decimation_mode = EnumProperty(

--- a/resources/translations.csv
+++ b/resources/translations.csv
@@ -900,6 +900,9 @@ Not checking this will always apply transforms",,
 Scene.merge_armatures_remove_zero_weight_bones.label,Remove Zero Weight Bones,ゼロウェイトボーンを削除する,제로 웨이트 본 제거
 Scene.merge_armatures_remove_zero_weight_bones.desc,"Cleans up the bones hierarchy, deleting all bones that don't directly affect any vertices.
 Uncheck this if bones or vertex groups that you want to keep got deleted",,
+Scene.merge_armatures_cleanup_shape_keys.label,Cleanup Shape Keys,
+Scene.merge_armatures_cleanup_shape_keys.desc,"Cleans up the meshes shape keys.
+Uncheck this if shape keys you want to keep got deleted",,
 Scene.decimation_mode.label,Decimation Mode,単純化モード,
 Scene.decimation_mode.desc,Decimation Mode,,
 Scene.decimation_mode.smart.label,Smart,スマート,

--- a/tools/armature_custom.py
+++ b/tools/armature_custom.py
@@ -380,10 +380,11 @@ def merge_armatures(base_armature_name, merge_armature_name, mesh_only, mesh_nam
     armature = Common.get_armature(armature_name=base_armature_name)
 
     # Clean up shape keys
-    for mesh_base in meshes_base:
-        Common.clean_shapekeys(mesh_base)
-    for mesh_merge in meshes_merge:
-        Common.clean_shapekeys(mesh_merge)
+    if bpy.context.scene.merge_armatures_cleanup_shape_keys:
+        for mesh_base in meshes_base:
+            Common.clean_shapekeys(mesh_base)
+        for mesh_merge in meshes_merge:
+            Common.clean_shapekeys(mesh_merge)
 
     # Join the meshes
     if bpy.context.scene.merge_armatures_join_meshes:

--- a/ui/custom.py
+++ b/ui/custom.py
@@ -57,6 +57,10 @@ class CustomPanel(ToolPanel, bpy.types.Panel):
             row = col.row(align=True)
             row.scale_y = 0.95
             row.prop(context.scene, 'merge_armatures_remove_zero_weight_bones')
+            
+            row = col.row(align=True)
+            row.scale_y = 0.95
+            row.prop(context.scene, 'merge_armatures_cleanup_shape_keys')
 
             row = col.row(align=True)
             row.scale_y = 1.05


### PR DESCRIPTION
I added a checkbox to Custom Model Creation -> Merge Armature that lets you disable the automatic shape key cleanup while merging.

This was an issue for me since I regularly use empty "placeholder" shape keys to keep things more sorted, something like "--- Visemes" with all the visemes below and "--- Body" with all the body shape keys below. 