### PR TITLE
Add barebones UVPM3 support

### DIFF
--- a/tools/bake.py
+++ b/tools/bake.py
@@ -1041,6 +1041,22 @@ class BakeButton(bpy.types.Operator):
                     for _ in range(1, 3):
                         bpy.ops.uvpackmaster2.uv_pack()
                 except AttributeError:
+                    pass
+                    
+                try:
+                    context.scene.uvpm3_props.normalize_islands = False
+                    context.scene.uvpm3_props.lock_overlapping_enable = True
+                    context.scene.uvpm3_props.lock_overlapping_mode = ('1' if
+                                                                      layer == 'CATS UV Super' else
+                                                                      '2')
+                    context.scene.uvpm3_props.pack_to_others = False
+                    context.scene.uvpm3_props.margin = margin
+                    context.scene.uvpm3_props.simi_threshold = 3
+                    context.scene.uvpm3_props.precision = 1000
+                    # Give UVP a static number of iterations to do TODO: make this configurable?
+                    for _ in range(1, 3):
+                        bpy.ops.uvpackmaster3.pack(mode_id='pack.single_tile')
+                except AttributeError:
                     bpy.ops.uv.pack_islands(rotate=True, margin=margin)
                     pass
                 Common.switch('OBJECT')

--- a/tools/bake.py
+++ b/tools/bake.py
@@ -1028,6 +1028,8 @@ class BakeButton(bpy.types.Operator):
                 # detect if UVPackMaster installed and configured
                 if not overlap_aware:
                     bpy.ops.uv.pack_islands(rotate=True, margin=margin)
+                    
+                if 'uvpm3_props' in context.scene.uvpm3_props.
                 try:  # UVP doesn't respect margins when called like this, find out why
                     context.scene.uvpm3_props.normalize_islands = False
                     context.scene.uvpm3_props.lock_overlapping_enable = True
@@ -1038,6 +1040,8 @@ class BakeButton(bpy.types.Operator):
                     context.scene.uvpm3_props.margin = margin
                     context.scene.uvpm3_props.simi_threshold = 3
                     context.scene.uvpm3_props.precision = 1000
+                    context.scene.uvpm3_props.rotation_enable = True
+                    context.scene.uvpm3_props.rotation_step = 1
                     # Give UVP a static number of iterations to do TODO: make this configurable?
                     for _ in range(1, 3):
                         bpy.ops.uvpackmaster3.pack(mode_id='pack.single_tile')

--- a/tools/bake.py
+++ b/tools/bake.py
@@ -1029,21 +1029,6 @@ class BakeButton(bpy.types.Operator):
                 if not overlap_aware:
                     bpy.ops.uv.pack_islands(rotate=True, margin=margin)
                 try:  # UVP doesn't respect margins when called like this, find out why
-                    context.scene.uvp2_props.normalize_islands = False
-                    context.scene.uvp2_props.lock_overlapping_mode = ('0' if
-                                                                      layer == 'CATS UV Super' else
-                                                                      '2')
-                    context.scene.uvp2_props.pack_to_others = False
-                    context.scene.uvp2_props.margin = margin
-                    context.scene.uvp2_props.similarity_threshold = 3
-                    context.scene.uvp2_props.precision = 1000
-                    # Give UVP a static number of iterations to do TODO: make this configurable?
-                    for _ in range(1, 3):
-                        bpy.ops.uvpackmaster2.uv_pack()
-                except AttributeError:
-                    pass
-                    
-                try:
                     context.scene.uvpm3_props.normalize_islands = False
                     context.scene.uvpm3_props.lock_overlapping_enable = True
                     context.scene.uvpm3_props.lock_overlapping_mode = ('1' if
@@ -1056,6 +1041,21 @@ class BakeButton(bpy.types.Operator):
                     # Give UVP a static number of iterations to do TODO: make this configurable?
                     for _ in range(1, 3):
                         bpy.ops.uvpackmaster3.pack(mode_id='pack.single_tile')
+                except AttributeError:
+                    pass
+                    
+                try:
+                    context.scene.uvp2_props.normalize_islands = False
+                    context.scene.uvp2_props.lock_overlapping_mode = ('0' if
+                                                                      layer == 'CATS UV Super' else
+                                                                      '2')
+                    context.scene.uvp2_props.pack_to_others = False
+                    context.scene.uvp2_props.margin = margin
+                    context.scene.uvp2_props.similarity_threshold = 3
+                    context.scene.uvp2_props.precision = 1000
+                    # Give UVP a static number of iterations to do TODO: make this configurable?
+                    for _ in range(1, 3):
+                        bpy.ops.uvpackmaster2.uv_pack()
                 except AttributeError:
                     bpy.ops.uv.pack_islands(rotate=True, margin=margin)
                     pass


### PR DESCRIPTION
I did this in an attempt to add bare bones basic UVPM3 support to cats-blender-plugin

I'm not sure what 
`context.scene.uvpm3_props.lock_overlapping_mode = '0'` used to be, but there seems to only be mode `1` and `2` now. Where mode `1` is equivalent to "Any Part" in the UI and `2` is equivalent to "exact". I'm also not sure exactly what this does on the cats side of things. Please let me know more about this and I can reassess the situation on my end and possibly fix what is wrong.

I noticed the default margin in uvpm3 is 
`context.scene.uvpm3_props.margin = 0.003`
but I think cat's defaults to much higher...
I initially considered hard coding this at `0.003` but left it set to `margin` for now. 


There's also rotation options which might enable even tighter packing
```
context.scene.uvpm3_props.rotation_enable = True
context.scene.uvpm3_props.rotation_step = 15
```
but I'm not sure what kind of pixel blur/quality loss might be caused as a result of this. Initially I hard coded these to be on, but I removed it after considering the quality implications. It might be worth adding these options to cats configuration somewhere at some point? I think as it is, the script might default to using whatever the user has picked under the UVPM3 menu in the UV editor? I'm truthfully not very familiar with blender plugin development or how it works. 


Please feel free to let me know what you think or let me know of any changes I should make. 