### PR TITLE
Add Bake Texture Quality Settings and many Bake optimisations and bug fixes

### DIFF
--- a/extentions.py
+++ b/extentions.py
@@ -8,7 +8,7 @@ from .tools import translations as Translations
 from .tools.translations import t
 
 from bpy.types import Scene, Material, PropertyGroup
-from bpy.props import BoolProperty, EnumProperty, FloatProperty, IntProperty, CollectionProperty, IntVectorProperty, StringProperty, FloatVectorProperty
+from bpy.props import BoolProperty, EnumProperty, FloatProperty, IntProperty, CollectionProperty, IntVectorProperty, StringProperty, FloatVectorProperty, PointerProperty
 from bpy.utils import register_class
 
 
@@ -635,6 +635,103 @@ def register():
     )
 
     Scene.bake_steam_library = StringProperty(name='Steam Library', default="C:\\Program Files (x86)\\Steam\\")
+
+    Scene.bake_samples_quality = EnumProperty(
+        items=[('HIGH', 'High', 'High quality.\nRecommended to use once Bake is all set up'),
+               ('LOW', 'Low', 'Low quality.\n1/4 the detail of High, but usually still looks pretty good, and usually twice as fast.'),
+               ('LOWEST', 'Lowest', 'Fastest and lowest possible quality.\nCan be used with a low Resolution setting to more quickly preview a Bake'),
+               ('CUSTOM', 'Custom (advanced)', 'Advanced users can manually set the samples of each baked texture with this setting.\nThe sliders max out at the High Quality preset, but higher values can be typed in manually')],
+        name='Texture Quality',
+        description="Adjust the quality of baked textures. This setting has a large effect on how long the bake takes.",
+        default='HIGH',
+    )
+
+    class BakeSamplesPropertyGroup(PropertyGroup):
+        diffuse: IntProperty(
+            name="Diffuse samples",
+            description="Number of samples to use for the diffuse pass",
+            default=32,
+            min=1,
+            soft_max=32,
+        )
+        smoothness: IntProperty(
+            name="Smoothness samples",
+            description="Number of samples to use for the smoothness pass",
+            default=32,
+            min=1,
+            soft_max=32,
+        )
+        alpha: IntProperty(
+            name="Transparency samples",
+            description="Number of samples to use for the transparency pass",
+            default=32,
+            min=1,
+            soft_max=32,
+        )
+        metallic: IntProperty(
+            name="Metallic samples",
+            description="Number of samples to use for the metallic pass",
+            default=32,
+            min=1,
+            soft_max=32,
+        )
+        normal_world: IntProperty(
+            name="Normal (world) samples",
+            description="Number of samples to use for the world normal pass\nThis is an intermediate step in baking normals",
+            default=128,
+            min=1,
+            soft_max=128,
+        )
+        normal_tangent: IntProperty(
+            name="Normal (tangent) samples",
+            description="Number of samples to use for the tangent normal pass\nThis is the output normal map",
+            default=128,
+            min=1,
+            soft_max=128,
+        )
+        ao: IntProperty(
+            name="Ambient Occlusion samples",
+            description="Number of samples to use for the ambient occlusion pass",
+            default=512,
+            min=1,
+            # AO can look bad without at least a few samples
+            soft_min=4,
+            soft_max=512,
+        )
+        emit: IntProperty(
+            name="Emit samples",
+            description="Number of samples to use for the emission pass\nThis is the basic emit pass without projected light",
+            default=32,
+            min=1,
+            soft_max=32,
+        )
+        emit_indirect: IntProperty(
+            name="Emit (projected light) samples",
+            description="Number of samples to use for the projected light emission pass",
+            default=512,
+            min=1,
+            soft_max=512,
+        )
+        emit_indirect_eyes: IntProperty(
+            name="Emit (projected light eyes) samples",
+            description="Number of samples to use for the eye exclusion projected light emission pass",
+            default=32,
+            min=1,
+            soft_max=32,
+        )
+        vertex_diffuse: IntProperty(
+            name="Vertex Diffuse samples",
+            description="Number of samples to use when baking diffuse to vertex colors",
+            default=32,
+            min=1,
+            soft_max=32,
+        )
+
+    register_class(BakeSamplesPropertyGroup)
+
+    Scene.bake_advanced_samples = PointerProperty(
+        type=BakeSamplesPropertyGroup
+    )
 
     Scene.selection_mode = EnumProperty(
         name=t('Scene.selection_mode.label'),

--- a/tools/bake.py
+++ b/tools/bake.py
@@ -31,6 +31,7 @@ import subprocess
 import shutil
 import threading
 from typing import NamedTuple
+from time import perf_counter
 
 from . import common as Common
 from .register import register_wrap
@@ -671,6 +672,8 @@ class BakeButton(bpy.types.Operator):
         return recurse(ob, ob.parent, 0, ignore_hidden, view_layer=view_layer)
 
     def execute(self, context):
+        bake_start = perf_counter()
+
         if not [obj for obj in Common.get_meshes_objects(check=False) if not Common.is_hidden(obj) or not context.scene.bake_ignore_hidden]:
             self.report({'ERROR'}, t('cats_bake.error.no_meshes'))
             return {'FINISHED'}
@@ -713,6 +716,12 @@ class BakeButton(bpy.types.Operator):
         # Change render engine back to original
         context.scene.render.engine = render_engine_tmp
         context.scene.cycles.device = render_device_tmp
+
+        bake_end = perf_counter()
+
+        bake_duration = bake_end - bake_start
+
+        print(f'Bake completed in {bake_duration} seconds')
 
         return {'FINISHED'}
 

--- a/tools/bake.py
+++ b/tools/bake.py
@@ -1451,7 +1451,8 @@ class BakeButton(bpy.types.Operator):
             vmtfile = "\"VertexlitGeneric\"\n{\n    \"$surfaceprop\" \"Flesh\""
             images_path = steam_library_path+"steamapps/common/GarrysMod/garrysmod/"
             target_dir = steam_library_path+"steamapps/common/GarrysMod/garrysmod/addons/"+sanitized_model_name+"_playermodel/materials/models/"+sanitized_model_name
-            os.makedirs(target_dir,0o777,True)
+            if export_format == "GMOD":
+                os.makedirs(target_dir, 0o777, True)
 
             generate_prop_bones = platform.generate_prop_bones
             generate_prop_bone_max_influence_count = platform.generate_prop_bone_max_influence_count

--- a/tools/bake.py
+++ b/tools/bake.py
@@ -2380,15 +2380,17 @@ class BakeButton(bpy.types.Operator):
 
             # Rebake diffuse to vertex colors: Incorperates AO
             if pass_diffuse and diffuse_vertex_colors:
-                for obj in plat_collection.all_objects:
-                    if obj.type == "MESH":
-                        context.view_layer.objects.active = obj
-                        bpy.ops.mesh.vertex_color_add()
+                plat_collection_meshes = [obj for obj in plat_collection.all_objects if obj.type == "MESH"]
+                for obj in plat_collection_meshes:
+                    context.view_layer.objects.active = obj
+                    bpy.ops.mesh.vertex_color_add()
 
-                self.swap_links([obj for obj in plat_collection.all_objects if obj.type == "MESH"], "Metallic", "Anisotropic Rotation")
-                self.set_values([obj for obj in plat_collection.all_objects if obj.type == "MESH"], "Metallic", 0.0)
-                self.bake_pass(context, vertex_diffuse_settings, [obj for obj in plat_collection.all_objects if obj.type == "MESH"])
-                self.swap_links([obj for obj in plat_collection.all_objects if obj.type == "MESH"], "Metallic", "Anisotropic Rotation")
+
+
+                self.swap_links(plat_collection_meshes, "Metallic", "Anisotropic Rotation")
+                self.set_values(plat_collection_meshes, "Metallic", 0.0)
+                self.bake_pass(context, vertex_diffuse_settings, plat_collection_meshes)
+                self.swap_links(plat_collection_meshes, "Metallic", "Anisotropic Rotation")
 
                 # TODO: If we're not baking anything else in, remove all UV maps entirely
 

--- a/ui/bake.py
+++ b/ui/bake.py
@@ -291,6 +291,8 @@ class BakePanel(ToolPanel, bpy.types.Panel):
             col.label(text=t('BakePanel.generaloptionslabel'))
             row = col.row(align=True)
             row.prop(context.scene, 'bake_resolution', expand=True)
+            # Texture quality (samples control)
+            self.draw_bake_panel_texture_quality(context, col)
             row = col.row(align=True)
             row.prop(context.scene, 'bake_ignore_hidden', expand=True)
             row = col.row(align=True)
@@ -487,4 +489,74 @@ class BakePanel(ToolPanel, bpy.types.Panel):
                 row = col.row(align=True)
                 row.separator()
                 row.label(text=name + ": " + "{:.1f}".format(1.0/bpy.data.objects[name].scale[0]) + "x", icon="OBJECT_DATA")
+
+    @staticmethod
+    def draw_bake_panel_texture_quality(context, col):
+        row = col.row(align=True)
+        row.label(text='Texture Quality')
+        row.prop(context.scene, 'bake_samples_quality', text='')
+        if context.scene.bake_samples_quality == 'CUSTOM':
+            at_least_one_bake_pass = False
+            row = col.row(align=True)
+            row.separator()
+            col2 = row.column(align=True)
+            col2.separator()
+            # Order these in the same order as the bake passes
+            if context.scene.bake_pass_diffuse:
+                at_least_one_bake_pass = True
+                row = col2.row(align=True)
+                row.prop(context.scene.bake_advanced_samples, 'diffuse')
+                vertex_diffuse_used = False
+                for platform in context.scene.bake_platforms:
+                    if platform.diffuse_vertex_colors:
+                        vertex_diffuse_used = True
+                        break
+                if vertex_diffuse_used:
+                    row = col2.row(align=True)
+                    row.prop(context.scene.bake_advanced_samples, 'vertex_diffuse')
+                col2.separator()
+            if context.scene.bake_pass_normal:
+                at_least_one_bake_pass = True
+                row = col2.row(align=True)
+                row.prop(context.scene.bake_advanced_samples, 'normal_world')
+                row = col2.row(align=True)
+                row.prop(context.scene.bake_advanced_samples, 'normal_tangent')
+                col2.separator()
+            if context.scene.bake_pass_smoothness:
+                at_least_one_bake_pass = True
+                row = col2.row(align=True)
+                row.prop(context.scene.bake_advanced_samples, 'smoothness')
+                col2.separator()
+            if context.scene.bake_pass_ao:
+                at_least_one_bake_pass = True
+                row = col2.row(align=True)
+                row.prop(context.scene.bake_advanced_samples, 'ao')
+                col2.separator()
+            if context.scene.bake_pass_alpha:
+                at_least_one_bake_pass = True
+                row = col2.row(align=True)
+                row.prop(context.scene.bake_advanced_samples, 'alpha')
+                col2.separator()
+            if context.scene.bake_pass_metallic:
+                at_least_one_bake_pass = True
+                row = col2.row(align=True)
+                row.prop(context.scene.bake_advanced_samples, 'metallic')
+                col2.separator()
+            if context.scene.bake_pass_emit:
+                at_least_one_bake_pass = True
+                if not context.scene.bake_emit_indirect:
+                    row = col2.row(align=True)
+                    row.prop(context.scene.bake_advanced_samples, 'emit')
+                    col2.separator()
+                else:
+                    row = col2.row(align=True)
+                    row.prop(context.scene.bake_advanced_samples, 'emit_indirect')
+                    if context.scene.bake_emit_exclude_eyes:
+                        row = col2.row(align=True)
+                        row.prop(context.scene.bake_advanced_samples, 'emit_indirect_eyes')
+                    col2.separator()
+            if not at_least_one_bake_pass:
+                row = col2.row(align=True)
+                row.label(text="No bake passes enabled")
+                col2.separator()
 


### PR DESCRIPTION
This pr grew a bit out of control as I kept finding more bugs to replace the ones I fixed. I think it's a good time for a break, so I've left it as separate commits for now and I, or someone else, can squash it all later if needed. Let me know of any issues.

New features:
1. Texture Quality (samples) dropdown
    - 4 options to choose from:
    - High: Same behaviour as the Bake Button before 
    - Low: 1/4 the number of samples as High. I find it bakes in about half the time as High and I honestly can't tell the difference between the two
    - Lowest: Intended as a much quicker and lower quality preview. Every pass set to 1 sample, except AO which is set to 4, because it looks really really bad with less than that
    - Custom (advanced): Displays sliders for all of the enabled passes, soft-capped between the samples of Lowest Quality and the samples of High Quality, though any integer greater than zero can be typed in
    - ![image](https://user-images.githubusercontent.com/495015/155873850-2973ae5f-8a00-42b4-a695-8462756b9ba1.png)
    - ![image](https://user-images.githubusercontent.com/495015/155873874-f016332d-e80b-4dd4-834e-f62e856336f2.png)



Improvements/changes (mostly replacing iteration of large lists with numpy and using foreach_get and foreach_set methods):
1. Massive performance increase for code that reads and writes pixels. Painstakingly slow is an understatement for the old code trying to copy, update and iterate through the pixels of 4096x4096 images
    - Pretty much everything that touched image.pixels has been entirely replaced
3. Optimised UNMIRROR and MANUAL uv overlap correction
    - uvs retreived and updated directly with foreach_get and foreach_set
5. Optimised optimize_solid_materials
    - No more swapping in and our of edit mode
    - No more iterating through the polygons to get the loop_indices
6. Optimised face prioritisation
7. Organised the settings for each of the bake passes into one place instead of strewn across the code wherever the bake_pass function is called
6. Moved conditional checks outside of a bunch of for loops so the conditions are only evaluated once (or fewer times for nested loops) instead of every loop
8. Added a contextmanager decorated function for temporarily unlinking BSDF input nodes and replacing their default_values, automatically restoring the links and default_values once done
9. Iteration of bake_<bake_name> shader value nodes now also iterates through all group nodes
10. Prop bone generation now finds all the vertex groups that have a corresponding bone ahead of time, and only counts and searches for those vertex groups
11. Bake duration added to terminal output

Fixes:
1. GMOD specific directories attempt to be created even when the export type is not GMOD
12. Polygons belonging to solid materials when optimize_solid_materials is enabled are uv unwrapped when they shouldn't be
13. Solid colour square creation mistakenly re-copies the entire image every time a new solid colour square is added
14. Shape keys with the same name in multiple meshes get restored to the same value after being temporarily disabled during shape key baking
15. Non 1.0 alpha messes up diffuse bakes
    - Would multiply with the colour making the bake too dark
17. 0.0 alpha messes up roughness bakes
    - Areas of exactly zero alpha would end up with zero smoothness
19. Some passes erase the original values of lesser used BSDF inputs without restoring them
20. Color texture's rgb are multiplied by their alpha channel during bakes resulting in much darker bakes on transparent areas
22. Iteration of bake_<bake_name> shader nodes only checks the active material of each object
23. Creating or repurposing the image texture node that will be baked to and setting it as active is mistakenly done once for every shader node
24. optimize_solid_materials errors when a material slot is empty
25. optimize_solid_materials counts the same solid material multiple times, resulting in the wrong index and placing uvs in the wrong place
26. Prop bone generation errors when a candidate vertex group has no corresponding bone
27. The non-indirect emit pass is missing its solidmaterialcolors argument
28. The indirect emit pass is missing the 'GLOSSY' Blender bake pass resulting in indirect emission being dimmer than it should be (maybe this was done on purpose? It seems to be an odd omission to me)
29. Non 1.0 alpha messes up emission bakes
    - Would multiply with the colour making the bake too dark
30. Solid colour emission causes the entire material to be considered a solid colour for optimize_solid_materials, even if the other passes are not solid

Issues still present:
1. LOD Add/Delete buttons error when clicked
2. Image sharpening occurs after solid material optimisation, causing artifacting on the solid colour squares
3. Enabling specular setup, changing normal alpha to specular and then disabling specular setup causes an error during bake when it still tries to pack specular in normal alpha even though specular is disabled
4. object.show_only_shape_key ('shape key pinning') most likely breaks everywhere that relies on new shape keys created from a specifically set up current mix
   - No idea who would use this, but handling it properly would make the code more robust

General performance and tidiness notes from having worked on this existing code:
1. If an expression can be done outside of a loop, do so instead of re-evaluating the expression in every loop
2. uvs in UV layers can be iterated directly, there's no need to iterate through all the polygons to iterate through all the loop_indices to get uvs by subscripting the uv_layer with each loop index
3. If there's a way to do something with an operator and there's a way to it without, the operator is almost always slower
    - e.g. use object.shape_key_add instead of bpy.ops.object.shape_key_add
4. Avoid going in and out of edit mode as much as possible, if you can manipulate the data directly in Object mode, it's usually faster.
4. DRY: Don't Repeat Yourself
    - There were a boatload of list comprehensions creating the exact same list, if it's not going to be modified, use the same list over and over (or use a tuple so you can guarantee that it can't be modified)
6. If you're adding, subtracting, multiplying and modulus-ing integers together, the result is always going to be an integer.
    - You can use `//` for integer division instead of int(a/b)
7. If you need to iterate through a big list to find things and then need those things for something later on, don't iterate through that big list a second time, store those things in their own list when you find them the first time and get them from that new list when you need them again
8. I'm not well versed on Python's garbage collector, but I think that if you have a ginormous function that takes ages, e.g. perform_bake, none of the variables are going to go out of scope and be garbage collected until the function returns or the variables are overwritten or deleted with `del`.
    - A list containing all the pixels of a single 4096x4096, 4 channel image stored as 32bit floats is 256MB of data that could be sitting around doing nothing until the function returns. (a 2048x2048 image would be 64MB instead)
    - Splitting up the code into separate functions that do one job only would be my preference, but I didn't want to completely obliterate the structure of the original code with the changes here