### PR TITLE
Export issues with Blender 3.1

### DIFF
--- a/tools/importer.py
+++ b/tools/importer.py
@@ -329,7 +329,7 @@ class ZipPopup(bpy.types.Operator):
 
     def invoke(self, context, event):
         dpi_value = Common.get_user_preferences().system.dpi
-        return context.window_manager.invoke_props_dialog(self, width=dpi_value * 6)
+        return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * 6))
 
     def check(self, context):
         # Important for changing options
@@ -396,7 +396,7 @@ class ModelsPopup(bpy.types.Operator):
 
     def invoke(self, context, event):
         dpi_value = Common.get_user_preferences().system.dpi
-        return context.window_manager.invoke_props_dialog(self, width=dpi_value * 3)
+        return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * 3))
 
     def check(self, context):
         # Important for changing options
@@ -560,7 +560,7 @@ class InstallXPS(bpy.types.Operator):
 
     def invoke(self, context, event):
         dpi_value = Common.get_user_preferences().system.dpi
-        return context.window_manager.invoke_props_dialog(self, width=dpi_value * 4.5)
+        return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * 4.5))
 
     def check(self, context):
         # Important for changing options
@@ -597,7 +597,7 @@ class InstallSource(bpy.types.Operator):
 
     def invoke(self, context, event):
         dpi_value = Common.get_user_preferences().system.dpi
-        return context.window_manager.invoke_props_dialog(self, width=dpi_value * 4.5)
+        return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * 4.5))
 
     def check(self, context):
         # Important for changing options
@@ -634,7 +634,7 @@ class InstallVRM(bpy.types.Operator):
 
     def invoke(self, context, event):
         dpi_value = Common.get_user_preferences().system.dpi
-        return context.window_manager.invoke_props_dialog(self, width=dpi_value * 4.5)
+        return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * 4.5))
 
     def check(self, context):
         # Important for changing options
@@ -670,7 +670,7 @@ class EnableMMD(bpy.types.Operator):
 
     def invoke(self, context, event):
         dpi_value = Common.get_user_preferences().system.dpi
-        return context.window_manager.invoke_props_dialog(self, width=dpi_value * 4)
+        return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * 4))
 
     def check(self, context):
         # Important for changing options
@@ -2086,7 +2086,7 @@ class ErrorDisplay(bpy.types.Operator):
         self.eye_meshes_not_named_body = _eye_meshes_not_named_body
 
         dpi_value = Common.get_user_preferences().system.dpi
-        return context.window_manager.invoke_props_dialog(self, width=dpi_value * 6.1)
+        return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * 6.1))
 
     def check(self, context):
         # Important for changing options

--- a/updater.py
+++ b/updater.py
@@ -167,7 +167,7 @@ class ShowPatchnotesPanel(bpy.types.Operator):
         global used_updater_panel
         used_updater_panel = True
         dpi_value = get_user_preferences().system.dpi
-        return context.window_manager.invoke_props_dialog(self, width=dpi_value * 8.2)
+        return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * 8.2))
 
     def check(self, context):
         # Important for changing options
@@ -216,7 +216,7 @@ class ConfirmUpdatePanel(bpy.types.Operator):
 
     def invoke(self, context, event):
         dpi_value = get_user_preferences().system.dpi
-        return context.window_manager.invoke_props_dialog(self, width=dpi_value * 4.1)
+        return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * 4.1))
 
     def check(self, context):
         # Important for changing options
@@ -280,7 +280,7 @@ class UpdateCompletePanel(bpy.types.Operator):
 
     def invoke(self, context, event):
         dpi_value = get_user_preferences().system.dpi
-        return context.window_manager.invoke_props_dialog(self, width=dpi_value * 4.1)
+        return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * 4.1))
 
     def check(self, context):
         # Important for changing options
@@ -329,7 +329,7 @@ class UpdateNotificationPopup(bpy.types.Operator):
 
     def invoke(self, context, event):
         dpi_value = get_user_preferences().system.dpi
-        return context.window_manager.invoke_props_dialog(self, width=dpi_value * 4.6)
+        return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * 4.6))
 
     # def invoke(self, context, event):
     #     return context.window_manager.invoke_props_dialog(self)


### PR DESCRIPTION
All of the usages of invoke_props_dialog that have a non integer width argument are going to need to have the width argument be cast to int or similar. #379 

PR in the good branche this time.
