### PR TITLE
Wrapper to fix empty and out-of-bounds EnumPropertys and fix their garbled UI text.

### DIFF
--- a/extentions.py
+++ b/extentions.py
@@ -1,4 +1,5 @@
 from .tools import common as Common
+from .tools.common import wrap_dynamic_enum_items
 from .tools import atlas as Atlas
 from .tools import eyetracking as Eyetracking
 from .tools import rootbone as Rootbone
@@ -16,14 +17,14 @@ def register():
     Scene.armature = EnumProperty(
         name=t('Scene.armature.label'),
         description=t('Scene.armature.desc'),
-        items=Common.get_armature_list,
-        update=Common.update_material_list
+        items=wrap_dynamic_enum_items(Common.get_armature_list, 'armature', sort=False, in_place=False),
+        update=Common.update_material_list,
     )
 
     Scene.zip_content = EnumProperty(
         name=t('Scene.zip_content.label'),
         description=t('Scene.zip_content.desc'),
-        items=Importer.get_zip_content
+        items=wrap_dynamic_enum_items(Importer.get_zip_content, 'zip_content'),
     )
 
     Scene.keep_upper_chest = BoolProperty(
@@ -125,25 +126,25 @@ def register():
     Scene.merge_armature_into = EnumProperty(
         name=t('Scene.merge_armature_into.label'),
         description=t('Scene.merge_armature_into.desc'),
-        items=Common.get_armature_list
+        items=wrap_dynamic_enum_items(Common.get_armature_list, 'merge_armature_into'),
     )
 
     Scene.merge_armature = EnumProperty(
         name=t('Scene.merge_armature.label'),
         description=t('Scene.merge_armature.desc'),
-        items=Common.get_armature_merge_list
+        items=wrap_dynamic_enum_items(Common.get_armature_merge_list, 'merge_armature'),
     )
 
     Scene.attach_to_bone = EnumProperty(
         name=t('Scene.attach_to_bone.label'),
         description=t('Scene.attach_to_bone.desc'),
-        items=Common.get_bones_merge
+        items=wrap_dynamic_enum_items(Common.get_bones_merge, 'attach_to_bone', sort=False),
     )
 
     Scene.attach_mesh = EnumProperty(
         name=t('Scene.attach_mesh.label'),
         description=t('Scene.attach_mesh.desc'),
-        items=Common.get_top_meshes
+        items=wrap_dynamic_enum_items(Common.get_top_meshes, 'attach_mesh'),
     )
 
     Scene.merge_same_bones = BoolProperty(
@@ -653,13 +654,13 @@ def register():
     Scene.add_shape_key = EnumProperty(
         name=t('Scene.add_shape_key.label'),
         description=t('Scene.add_shape_key.desc'),
-        items=Common.get_shapekeys_decimation
+        items=wrap_dynamic_enum_items(Common.get_shapekeys_decimation, 'add_shape_key'),
     )
 
     Scene.add_mesh = EnumProperty(
         name=t('Scene.add_mesh.label'),
         description=t('Scene.add_mesh.desc'),
-        items=Common.get_meshes_decimation
+        items=wrap_dynamic_enum_items(Common.get_meshes_decimation, 'add_mesh'),
     )
 
     Scene.decimate_fingers = BoolProperty(
@@ -700,49 +701,50 @@ def register():
     Scene.mesh_name_eye = EnumProperty(
         name=t('Scene.mesh_name_eye.label'),
         description=t('Scene.mesh_name_eye.desc'),
-        items=Common.get_meshes
+        # get_meshes is used elsewhere than for EnumProperty items so must contain the sorting itself
+        items=wrap_dynamic_enum_items(Common.get_meshes, 'mesh_name_eye', sort=False),
     )
 
     Scene.head = EnumProperty(
         name=t('Scene.head.label'),
         description=t('Scene.head.desc'),
-        items=Common.get_bones_head
+        items=wrap_dynamic_enum_items(Common.get_bones_head, 'head'),
     )
 
     Scene.eye_left = EnumProperty(
         name=t('Scene.eye_left.label'),
         description=t('Scene.eye_left.desc'),
-        items=Common.get_bones_eye_l
+        items=wrap_dynamic_enum_items(Common.get_bones_eye_l, 'eye_left'),
     )
 
     Scene.eye_right = EnumProperty(
         name=t('Scene.eye_right.label'),
         description=t('Scene.eye_right.desc'),
-        items=Common.get_bones_eye_r
+        items=wrap_dynamic_enum_items(Common.get_bones_eye_r, 'eye_right'),
     )
 
     Scene.wink_left = EnumProperty(
         name=t('Scene.wink_left.label'),
         description=t('Scene.wink_left.desc'),
-        items=Common.get_shapekeys_eye_blink_l
+        items=wrap_dynamic_enum_items(Common.get_shapekeys_eye_blink_l, 'wink_left', sort=False),
     )
 
     Scene.wink_right = EnumProperty(
         name=t('Scene.wink_right.label'),
         description=t('Scene.wink_right.desc'),
-        items=Common.get_shapekeys_eye_blink_r
+        items=wrap_dynamic_enum_items(Common.get_shapekeys_eye_blink_r, 'wink_right', sort=False),
     )
 
     Scene.lowerlid_left = EnumProperty(
         name=t('Scene.lowerlid_left.label'),
         description=t('Scene.lowerlid_left.desc'),
-        items=Common.get_shapekeys_eye_low_l
+        items=wrap_dynamic_enum_items(Common.get_shapekeys_eye_low_l, 'lowerlid_left', sort=False),
     )
 
     Scene.lowerlid_right = EnumProperty(
         name=t('Scene.lowerlid_right.label'),
         description=t('Scene.lowerlid_right.desc'),
-        items=Common.get_shapekeys_eye_low_r
+        items=wrap_dynamic_enum_items(Common.get_shapekeys_eye_low_r, 'lowerlid_right', sort=False),
     )
 
     Scene.disable_eye_movement = BoolProperty(
@@ -826,25 +828,26 @@ def register():
     Scene.mesh_name_viseme = EnumProperty(
         name=t('Scene.mesh_name_viseme.label'),
         description=t('Scene.mesh_name_viseme.desc'),
-        items=Common.get_meshes
+        # get_meshes is used elsewhere than for EnumProperty items so must contain the sorting itself
+        items=wrap_dynamic_enum_items(Common.get_meshes, 'mesh_name_viseme', sort=False),
     )
 
     Scene.mouth_a = EnumProperty(
         name=t('Scene.mouth_a.label'),
         description=t('Scene.mouth_a.desc'),
-        items=Common.get_shapekeys_mouth_ah,
+        items=wrap_dynamic_enum_items(Common.get_shapekeys_mouth_ah, 'mouth_a', sort=False),
     )
 
     Scene.mouth_o = EnumProperty(
         name=t('Scene.mouth_o.label'),
         description=t('Scene.mouth_o.desc'),
-        items=Common.get_shapekeys_mouth_oh,
+        items=wrap_dynamic_enum_items(Common.get_shapekeys_mouth_oh, 'mouth_o', sort=False),
     )
 
     Scene.mouth_ch = EnumProperty(
         name=t('Scene.mouth_ch.label'),
         description=t('Scene.mouth_ch.desc'),
-        items=Common.get_shapekeys_mouth_ch,
+        items=wrap_dynamic_enum_items(Common.get_shapekeys_mouth_ch, 'mouth_ch', sort=False),
     )
 
     Scene.shape_intensity = FloatProperty(
@@ -862,7 +865,8 @@ def register():
     Scene.root_bone = EnumProperty(
         name=t('Scene.root_bone.label'),
         description=t('Scene.root_bone.desc'),
-        items=Rootbone.get_parent_root_bones,
+        # Root bone choices get cached, so we don't want to fix them in-place, otherwise the cache would get modified
+        items=wrap_dynamic_enum_items(Rootbone.get_parent_root_bones, 'root_bone', sort=False, in_place=False),
     )
 
     # Optimize
@@ -910,13 +914,15 @@ def register():
     Scene.merge_mesh = EnumProperty(
         name=t('Scene.merge_mesh.label'),
         description=t('Scene.merge_mesh.desc'),
-        items=Common.get_meshes
+        # get_meshes is used elsewhere than for EnumProperty items so must contain the sorting itself
+        items=wrap_dynamic_enum_items(Common.get_meshes, 'merge_mesh', sort=False),
     )
 
     Scene.merge_bone = EnumProperty(
         name=t('Scene.merge_bone.label'),
         description=t('Scene.merge_bone.desc'),
-        items=Rootbone.get_parent_root_bones,
+        # Root bone choices get cached, so we don't want to fix them in-place, otherwise the cache would get modified
+        items=wrap_dynamic_enum_items(Rootbone.get_parent_root_bones, 'merge_bone', sort=False, in_place=False),
     )
 
     # Settings
@@ -941,7 +947,7 @@ def register():
     Scene.ui_lang = EnumProperty(
         name=t('Scene.ui_lang.label'),
         description=t('Scene.ui_lang.desc'),
-        items=Translations.get_languages_list,
+        items=wrap_dynamic_enum_items(Translations.get_languages_list, 'ui_lang', sort=False),
         update=Translations.update_ui
     )
     Scene.debug_translations = BoolProperty(

--- a/tools/armature.py
+++ b/tools/armature.py
@@ -1256,8 +1256,6 @@ class FixArmature(bpy.types.Operator):
             except RuntimeError:
                 pass
 
-        Common.reset_context_scenes()
-
         wm.progress_end()
 
         if not hierarchy_check_hips['result']:

--- a/tools/bonemerge.py
+++ b/tools/bonemerge.py
@@ -46,9 +46,7 @@ class BoneMergeButton(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if context.scene.merge_mesh == "" or context.scene.merge_bone == "":
-            return False
-        return True
+        return Common.is_enum_non_empty(context.scene.merge_mesh) and Common.is_enum_non_empty(context.scene.merge_bone)
 
     def execute(self, context):
         saved_data = Common.SavedData()

--- a/tools/common.py
+++ b/tools/common.py
@@ -45,6 +45,7 @@ from . import armature_bones as Bones
 from . import settings as Settings
 from .register import register_wrap
 from .translations import t
+from sys import intern
 
 from mmd_tools_local import utils
 from mmd_tools_local.panels import tool as mmd_tool
@@ -135,7 +136,7 @@ def get_armature(armature_name=None):
         armature_name = bpy.context.scene.armature
     for obj in get_objects():
         if obj.type == 'ARMATURE':
-            if (armature_name and obj.name == armature_name) or not armature_name:
+            if obj.name == armature_name or Common.is_enum_empty(armature_name):
                 return obj
     return None
 
@@ -297,10 +298,6 @@ def set_default_stage():
         if version_2_79_or_older():
             armature.layers[0] = True
 
-    # Fix broken armatures
-    if not bpy.context.scene.armature:
-        bpy.context.scene.armature = armature.name
-
     return armature
 
 
@@ -438,8 +435,7 @@ def get_meshes(self, context):
     for mesh in get_meshes_objects(mode=0, check=False):
         choices.append((mesh.name, mesh.name, mesh.name))
 
-    bpy.types.Object.Enum = sorted(choices, key=lambda x: tuple(x[0].lower()))
-    return bpy.types.Object.Enum
+    return _sort_enum_choices_by_identifier_lower(choices)
 
 
 def get_top_meshes(self, context):
@@ -448,18 +444,17 @@ def get_top_meshes(self, context):
     for mesh in get_meshes_objects(mode=1, check=False):
         choices.append((mesh.name, mesh.name, mesh.name))
 
-    bpy.types.Object.Enum = sorted(choices, key=lambda x: tuple(x[0].lower()))
-    return bpy.types.Object.Enum
+    return choices
 
 
+# currently unused
 def get_all_meshes(self, context):
     choices = []
 
     for mesh in get_meshes_objects(mode=2, check=False):
         choices.append((mesh.name, mesh.name, mesh.name))
 
-    bpy.types.Object.Enum = sorted(choices, key=lambda x: tuple(x[0].lower()))
-    return bpy.types.Object.Enum
+    return _sort_enum_choices_by_identifier_lower(choices)
 
 
 def get_armature_list(self, context):
@@ -476,11 +471,7 @@ def get_armature_list(self, context):
         # 3. will be shown in the hover description (below description)
         choices.append((armature.name, name, armature.name))
 
-    if len(choices) == 0:
-        choices.append(('None', 'None', 'None'))
-
-    bpy.types.Object.Enum = sorted(choices, key=lambda x: tuple(x[0].lower()))
-    return bpy.types.Object.Enum
+    return choices
 
 
 def get_armature_merge_list(self, context):
@@ -499,11 +490,7 @@ def get_armature_merge_list(self, context):
             # 3. will be shown in the hover description (below description)
             choices.append((armature.name, name, armature.name))
 
-    if len(choices) == 0:
-        choices.append(('None', 'None', 'None'))
-
-    bpy.types.Object.Enum = sorted(choices, key=lambda x: tuple(x[0].lower()))
-    return bpy.types.Object.Enum
+    return choices
 
 
 def get_meshes_decimation(self, context):
@@ -519,8 +506,7 @@ def get_meshes_decimation(self, context):
                 # 3. will be shown in the hover description (below description)
                 choices.append((object.name, object.name, object.name))
 
-    bpy.types.Object.Enum = sorted(choices, key=lambda x: tuple(x[0].lower()))
-    return bpy.types.Object.Enum
+    return choices
 
 
 def get_bones_head(self, context):
@@ -550,8 +536,7 @@ def get_bones(names=None, armature_name=None, check_list=False):
     armature = get_armature(armature_name=armature_name)
 
     if not armature:
-        bpy.types.Object.Enum = choices
-        return bpy.types.Object.Enum
+        return choices
 
     # print("")
     # print("START DEBUG UNICODE")
@@ -566,7 +551,7 @@ def get_bones(names=None, armature_name=None, check_list=False):
         except UnicodeDecodeError:
             print("ERROR", bone.name)
 
-    choices.sort(key=lambda x: tuple(x[0].lower()))
+    _sort_enum_choices_by_identifier_lower(choices)
 
     choices2 = []
     for name in names:
@@ -577,9 +562,7 @@ def get_bones(names=None, armature_name=None, check_list=False):
         for choice in choices:
             choices2.append(choice)
 
-    bpy.types.Object.Enum = choices2
-
-    return bpy.types.Object.Enum
+    return choices2
 
 
 def get_shapekeys_mouth_ah(self, context):
@@ -637,13 +620,11 @@ def get_shapekeys(context, names, is_mouth, no_basis, decimation, return_list):
         else:
             meshes = [get_objects().get(context.scene.mesh_name_eye)]
     else:
-        bpy.types.Object.Enum = choices
-        return bpy.types.Object.Enum
+        return choices
 
     for mesh in meshes:
         if not mesh or not has_shapekeys(mesh):
-            bpy.types.Object.Enum = choices
-            return bpy.types.Object.Enum
+            return choices
 
         for shapekey in mesh.data.shape_keys.key_blocks:
             name = shapekey.name
@@ -659,7 +640,7 @@ def get_shapekeys(context, names, is_mouth, no_basis, decimation, return_list):
             choices.append((name, name, name))
             choices_simple.append(name)
 
-    choices.sort(key=lambda x: tuple(x[0].lower()))
+    _sort_enum_choices_by_identifier_lower(choices)
 
     choices2 = []
     for name in names:
@@ -668,10 +649,7 @@ def get_shapekeys(context, names, is_mouth, no_basis, decimation, return_list):
                 continue
             choices2.append((name, name, name))
 
-    for choice in choices:
-        choices2.append(choice)
-
-    bpy.types.Object.Enum = choices2
+    choices2.extend(choices)
 
     if return_list:
         shape_list = []
@@ -679,7 +657,7 @@ def get_shapekeys(context, names, is_mouth, no_basis, decimation, return_list):
             shape_list.append(choice[0])
         return shape_list
 
-    return bpy.types.Object.Enum
+    return choices2
 
 
 def fix_armature_names(armature_name=None):
@@ -715,13 +693,12 @@ def fix_armature_names(armature_name=None):
 
 
 def get_texture_sizes(self, context):
-    bpy.types.Object.Enum = [
+    # Format is (identifier, name, description)
+    return [
         ("1024", "1024 (low)", "1024"),
         ("2048", "2048 (medium)", "2048"),
         ("4096", "4096 (high)", "4096")
     ]
-
-    return bpy.types.Object.Enum
 
 
 def get_meshes_objects(armature_name=None, mode=0, check=True, visible_only=False):
@@ -799,7 +776,6 @@ def join_meshes(armature_name=None, mode=0, apply_transformations=True, repair_s
     # Get meshes to join
     meshes_to_join = get_meshes_objects(armature_name=armature_name, mode=3 if mode == 1 else 0)
     if not meshes_to_join:
-        reset_context_scenes()
         return None
 
     set_default_stage()
@@ -875,8 +851,6 @@ def join_meshes(armature_name=None, mode=0, apply_transformations=True, repair_s
 
         if repair_shape_keys:
             repair_shapekey_order(mesh.name)
-
-    reset_context_scenes()
 
     # Update the material list of the Material Combiner
     update_material_list()
@@ -1177,24 +1151,6 @@ def separate_by_verts():
             bpy.ops.object.vertex_group_select()
             bpy.ops.mesh.separate(type='SELECTED')
         bpy.ops.object.mode_set(mode='OBJECT')
-
-
-def reset_context_scenes():
-    head_bones = get_bones_head(None, bpy.context)
-    if len(head_bones) > 0:
-        bpy.context.scene.head = head_bones[0][0]
-        bpy.context.scene.eye_left = get_bones_eye_l(None, bpy.context)[0][0]
-        bpy.context.scene.eye_right = get_bones_eye_r(None, bpy.context)[0][0]
-
-    meshes = get_meshes(None, bpy.context)
-    if len(meshes) > 0:
-        mesh = meshes[0][0]
-        if not bpy.context.scene.mesh_name_eye:
-            bpy.context.scene.mesh_name_eye = mesh
-        if not bpy.context.scene.mesh_name_viseme:
-            bpy.context.scene.mesh_name_viseme = mesh
-        if not bpy.context.scene.merge_mesh:
-            bpy.context.scene.merge_mesh = mesh
 
 
 def save_shapekey_order(mesh_name):
@@ -2276,6 +2232,264 @@ def html_to_text(html):
     except:  # HTMLParseError: No good replacement?
         pass
     return parser.get_text()
+
+
+# Default sorting for dynamic EnumProperty items
+def _sort_enum_choices_by_identifier_lower(choices, in_place=True):
+    """Sort a list of enum choices (items) by the lowercase of their identifier.
+
+    Sorting is performed in-place by default, but can be changed by setting in_place=False.
+
+    Returns the sorted list of enum choices."""
+
+    def identifier_lower(choice):
+        return choice[0].lower()
+
+    if in_place:
+        choices.sort(key=identifier_lower)
+    else:
+        choices = sorted(choices, key=identifier_lower)
+    return choices
+
+
+# Identifier to indicate that an EnumProperty is empty
+# This is the default identifier used when a wrapped items function returns an empty list
+# This identifier needs to be something that should never normally be used, so as to avoid the possibility of
+# conflicting with an enum value that exists.
+_empty_enum_identifier = 'Cats_empty_enum_identifier'
+
+
+def _ensure_enum_choices_not_empty(choices, in_place=True):
+    if not in_place:
+        choices = choices.copy()
+
+    num_choices = len(choices)
+    if num_choices == 0:
+        # An EnumProperty should always have at least one choice since enum properties work based on indices. If there
+        # aren't any choices, Blender falls back to '' as the returned value (the identifier), but choices that have ''
+        # as the identifier (or any other falsey value in the case of trying to use a subclass of str) get ignored for
+        # some reason, so we have to use a different identifier.
+        # format is (identifier, name, description)
+        choices.append((_empty_enum_identifier, 'None', '(auto-generated)'))
+
+    return choices
+
+
+# Cache used to ensure that all strings used by an EnumProperty maintain a reference in Python
+# Dict of {str: set(str)} where the keys are property paths and the values are sets of strings being cached
+_enum_string_cache = {}
+
+
+# Note: Assumes all properties belong to a scene and therefore only one instance of each property_path will exist at a
+#       time due to the fact that only one scene is active at a time.
+# Note: A CollectionProperty containing an EnumProperty will result in strings being left in the cache when elements in
+#       the CollectionProperty get deleted.
+#       These have a property_path like 'my_collection_prop[<index>].my_enum_prop' so if the number of indices decreases
+#       then some strings will get left in the cache.
+def _ensure_python_references(choices, property_path, in_place=True):
+    # Blender docs for EnumProperty:
+    #   "There is a known bug with using a callback, Python must keep a reference to the strings returned by the callback
+    #   or Blender will misbehave or even crash."
+    # This issue is much more visible in UI if you use row.props_enum(<property owner>, <property name>) instead of
+    # row.prop(<property owner>, <property name>) with an EnumProperty
+    # We'll make sure Python has its own references by interning all the strings and then putting them in a cache. Both
+    # steps are necessary as each step only covers some cases where the issue appears.
+    new_cache = set()
+
+    def keep_string_reference(element):
+        if isinstance(element, str):
+            element = intern(element)
+            new_cache.add(element)
+        return element
+
+    if in_place:
+        for i, choice in enumerate(choices):
+            choices[i] = tuple(map(keep_string_reference, choice))
+    else:
+        choices = [tuple(map(keep_string_reference, choice)) for choice in choices]
+
+    # When updating the cache, it's important that we don't temporarily remove any strings that are still in use,
+    # because UI may still be referencing and using those strings during the very brief time window where we've removed
+    # them in preparation of updating the cache
+    object_name_cache = _enum_string_cache.setdefault(property_path, set())
+    # Add all the new values
+    object_name_cache.update(new_cache)
+    # Remove any values no longer being used
+    object_name_cache.intersection_update(new_cache)
+    return choices
+
+
+# Keeps track of whether an enum property for a specific scene is scheduled to have its current choice fixed because
+# the current choice is invalid.
+# This is only used when the current choice is detected as being invalid while drawing UI, since UI drawing code cannot
+# modify properties.
+# Dictionary of {str: set(str)} where the keys are the scene name and the set elements are the property paths to be
+# fixed
+_enum_choice_fix_scheduled = {}
+
+
+# Check for, and fix out of bounds enum choices, settings the index to the last choice and adding temporary duplicate
+# choices so the index remains within the bounds for this call
+def _fix_out_of_bounds_enum_choices(property_holder, scene, choices, property_name, property_path, in_place=True):
+    """Check for and fix an EnumProperty if its index is out of bounds.
+
+    If it isn't possible to change the index immediately, because this is being called as part of a UI drawing method,
+    a task to change the active choice will be scheduled to run as soon as possible.
+
+    Adds duplicates of the last choice to 'choices' to prevent warnings until the invalid choices are fixed.
+
+    property_holder is the holder of the property, in an EnumProperty's items function, this is the 'self' argument
+
+    scene is the scene that owns the property, either directly or held in a PropertyGroup or PropertyCollection. It must
+    be the .id_data of the property.
+
+    choices is the list of choices returned by the EnumProperty's items function.
+
+    property_name is the name of the EnumProperty on the property_holder to be checked against whether the choices are
+    valid.
+
+    property_path is the full path from the owner of the EnumProperty (scene) to the EnumProperty itself. This can be
+    retrieved with property_holder.path_from_id(property_name).
+
+    By default, the passed in 'choices' argument is modified, this can be disabled by setting in_place=False.
+
+    Returns 'choices' with enough extra elements to avoid warnings of the property's index being out of bounds."""
+
+    if not in_place:
+        choices = choices.copy()
+
+    num_choices = len(choices)
+
+    # Getting property_holder.property_name isn't possible since it will cause infinite recursion, but we can get the
+    # index without issue
+    current_choice_index = property_holder.get(property_name)
+    # If the property is not yet initialised, it should get set to a valid index automatically, so we only care
+    # if it has already been initialised
+    is_initialised = current_choice_index is not None
+    if is_initialised and current_choice_index >= num_choices:
+        # If the index is out of bounds, the last choice is suitable
+        replacement_idx = num_choices - 1
+        replacement_choice = choices[replacement_idx]
+
+        # Setting the current choice index won't affect the current process of getting the property value, e.g.
+        # if current_choice_index was 5, setting scene[property_name] will have no affect until attempting to
+        # get the property a second time.
+        # What we can do is temporarily add duplicates of the replacement choice until there is a choice at the current,
+        # invalid index.
+        # Adding extra choices will prevent the console from being spammed with warnings about no enum existing for the
+        # current, invalid index.
+        # Note that Blender 2.79 would return the first choice when the index is out of bounds while newer versions
+        # return '', so this is slightly different behaviour.
+        num_extra_to_add = current_choice_index - num_choices + 1
+        # print(f"Current index of {property_name} is {current_choice_index}, but there are only {num_choices} values. Temporarily adding {num_extra_to_add} extra choices")
+        extra_choices = [replacement_choice, ] * num_extra_to_add
+        choices.extend(extra_choices)
+
+        try:
+            # If possible, set the current choice index to a valid one, this will raise an Attribute error if called
+            # when drawing UI.
+            property_holder[property_name] = replacement_idx
+            # print(f"Detected '{property_path}' enum in '{scene.name}' with an invalid value, it has been fixed automatically")
+        except AttributeError:
+            # bpy.app.timers is 2.80+
+            # For older Blender versions, it is possible to use a Thread to run the task until it works, but this
+            # would result in EnumProperty update functions being called from a separate Thread which does not
+            # sound like a good idea. It also might not be safe in general to get a scene and update one if its
+            # properties from a separate Thread, e.g., what if the scene is deleted in the time between getting the
+            # scene and updating the property's value?
+            # Without the scheduled task on 2.79, if the index is out of bounds, the temporary duplicates will
+            # be added every time the items function is called, until the EnumProperty is updated or retrieved
+            # outside of UI drawing. This causes the temporary duplicates to be visible in the UI. Though, selecting
+            # any of the temporary duplicates poses no problem as it causes the property to be updated outside of UI
+            # drawing, thus fixing the out-of-bounds index and causing the temporary duplicates to disappear.
+            if not version_2_79_or_older():
+                # No modification is allowed when called as part of drawing UI, so we must schedule a task instead
+                # First check if a fix has not already been scheduled, otherwise around 4 or 5 tasks could get scheduled
+                # before the first one fixes the invalid choice
+                scene_name = scene.name
+                # _enum_choice_fix_scheduled is a global variable
+                scheduled_property_set = _enum_choice_fix_scheduled.setdefault(scene_name, set())
+                if property_path not in scheduled_property_set:
+                    replacement_identifier = replacement_choice[0]
+
+                    scheduled_property_set.add(property_path)
+
+                    # Closure task to fix the property
+                    def fix_out_of_bounds_enum_choice_task():
+                        scene_by_name = bpy.data.scenes.get(scene_name)
+                        # It's unlikely, but it is possible that the scene could have been deleted or renamed by the
+                        # time the task executes. If it was renamed, another task would end up getting scheduled with
+                        # the new name, so no problems there.
+                        if scene_by_name:
+                            # False argument to not coerce into a Python object (the value of the property) and instead
+                            # return the prop itself
+                            prop = scene_by_name.path_resolve(property_path, False)
+                            # .id_data is the owner of the property, the scene in this case, and .data is the holder of
+                            # the property
+                            prop_holder = prop.data
+                            # Setting the index
+                            #   prop_holder[property_name] = replacement_idx
+                            # doesn't cause UI to update the list of items.
+                            # However, setting the property itself does, and since this is scheduled and called
+                            # separately, there's no issue of causing infinite recursion.
+                            # This will result in fix_invalid_enum_choices getting called again, but that will only fix
+                            # the index and not cause the UI to update.
+                            # Equivalent to: scene_by_name.property = replacement_identifier
+                            setattr(prop_holder, property_name, replacement_identifier)
+                            # print(f"Fixed '{property_path}' EnumProperty in '{scene_name}'")
+                        else:
+                            print("An EnumProperty fix was scheduled to set '{}.{}' to '{}', but the scene '{}' could not be found."
+                                  .format(scene_name, property_path, replacement_identifier, scene_name))
+                        scheduled_property_set.remove(property_path)
+                        # Returning None indicates that the timer should be removed after being executed; here for
+                        # clarity.
+                        return None
+
+                    # Schedule the task to immediately execute when possible (this will be after UI drawing has
+                    # finished)
+                    bpy.app.timers.register(fix_out_of_bounds_enum_choice_task)
+                    # print(f"Detected '{property_path}' enum in '{scene_name}' with an invalid value during UI drawing, a fix has been scheduled")
+
+    return choices
+
+
+def is_enum_empty(string):
+    """Returns True only if the tested string is the string that signifies that an EnumProperty is empty.
+
+    Returns False in all other cases."""
+    return _empty_enum_identifier == string
+
+
+# This function isn't needed since you can 'not is_enum_empty(string)', but is included for code clarity and readability
+def is_enum_non_empty(string):
+    """Returns False only if the tested string is not the string that signifies that an EnumProperty is empty.
+
+    Returns True in all other cases."""
+    return _empty_enum_identifier != string
+
+
+def wrap_dynamic_enum_items(items_func, property_name, sort=True, in_place=True):
+    """Wrap an EnumProperty items function to automatically fix the property when it goes out of bounds of the items list.
+    Automatically adds at least one choice if the items function returns an empty list.
+    By default, sorts the items by the lowercase of the identifiers, this can be disabled by setting sort=False.
+    Interns and caches all strings in the items to avoid a known Blender UI bug.
+    Only works for properties whose owner is a scene."""
+    def wrapped_items_func(self, context):
+        nonlocal in_place
+        items = items_func(self, context)
+        if sort:
+            items = _sort_enum_choices_by_identifier_lower(items, in_place=in_place)
+            if not in_place:
+                # Sorting has already created a new list in this case, so the rest can be done in place
+                in_place = True
+        items = _ensure_enum_choices_not_empty(items, in_place=in_place)
+        property_path = self.path_from_id(property_name)
+        # If ensuring the list wasn't empty wasn't done in place, then a new list has been created and the rest can
+        # be done in place
+        items = _ensure_python_references(items, property_path)
+        return _fix_out_of_bounds_enum_choices(self, context.scene, items, property_name, property_path)
+
+    return wrapped_items_func
 
 
 """ === THIS CODE COULD BE USEFUL === """

--- a/tools/decimation.py
+++ b/tools/decimation.py
@@ -48,10 +48,7 @@ class ScanButton(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if context.scene.add_shape_key == "":
-            return False
-
-        return True
+        return Common.is_enum_non_empty(context.scene.add_shape_key)
 
     def execute(self, context):
         shape = context.scene.add_shape_key
@@ -75,9 +72,7 @@ class AddShapeButton(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if context.scene.add_shape_key == "":
-            return False
-        return True
+        return Common.is_enum_non_empty(context.scene.add_shape_key)
 
     def execute(self, context):
         shape = context.scene.add_shape_key
@@ -101,9 +96,7 @@ class AddMeshButton(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if context.scene.add_mesh == "":
-            return False
-        return True
+        return Common.is_enum_non_empty(context.scene.add_mesh)
 
     def execute(self, context):
         ignore_meshes.append(context.scene.add_mesh)

--- a/tools/eyetracking.py
+++ b/tools/eyetracking.py
@@ -55,9 +55,9 @@ class CreateEyesButton(bpy.types.Operator):
         if not Common.get_meshes_objects(check=False):
             return False
 
-        if not context.scene.head \
-                or not context.scene.eye_left \
-                or not context.scene.eye_right:
+        if Common.is_enum_empty(context.scene.head) \
+                or Common.is_enum_empty(context.scene.eye_left) \
+                or Common.is_enum_empty(context.scene.eye_right):
             return False
 
         # if not context.scene.disable_eye_blinking:
@@ -87,10 +87,10 @@ class CreateEyesButton(bpy.types.Operator):
         old_eye_right = armature.data.edit_bones.get(context.scene.eye_right)
 
         # Check for errors
-        if not context.scene.disable_eye_blinking and (context.scene.wink_left == ""
-                                                       or context.scene.wink_right == ""
-                                                       or context.scene.lowerlid_left == ""
-                                                       or context.scene.lowerlid_right == ""):
+        if not context.scene.disable_eye_blinking and (Common.is_enum_empty(context.scene.wink_left)
+                                                       or Common.is_enum_empty(context.scene.wink_right)
+                                                       or Common.is_enum_empty(context.scene.lowerlid_left)
+                                                       or Common.is_enum_empty(context.scene.lowerlid_right)):
             saved_data.load()
             self.report({'ERROR'}, t('CreateEyesButton.error.noShapeSelected'))
             return {'CANCELLED'}

--- a/tools/importer.py
+++ b/tools/importer.py
@@ -369,11 +369,7 @@ def get_zip_content(self, context):
                 encode_str(file_name),
                 t('get_zip_content.choose', model=encode_str(file_name), zipName=encode_str(zip_name))))
 
-    if len(choices) == 0:
-        choices.append(('None', 'None', 'None'))
-
-    bpy.types.Object.Enum = sorted(choices, key=lambda x: tuple(x[0].lower()))
-    return bpy.types.Object.Enum
+    return choices
 
 
 def encode_str(s):

--- a/tools/rootbone.py
+++ b/tools/rootbone.py
@@ -42,9 +42,7 @@ class RootButton(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if context.scene.root_bone == "":
-            return False
-        return True
+        return Common.is_enum_non_empty(context.scene.root_bone)
 
     def execute(self, context):
         saved_data = Common.SavedData()
@@ -86,8 +84,7 @@ def get_parent_root_bones(self, context):
     choices = []
 
     if armature is None:
-        bpy.types.Object.Enum = choices
-        return bpy.types.Object.Enum
+        return choices
     armature = armature.data
 
     # Get cache if exists
@@ -156,13 +153,11 @@ def get_parent_root_bones(self, context):
             choices.append((rootbone, rootbone.replace('_R', '').replace('_L', '') + ' (' + str(len(bone_groups[rootbone])) + ' bones)', rootbone))
             bone_groups_tmp[rootbone] = bone_groups[rootbone]
 
-    bpy.types.Object.Enum = choices
-
     # set cache
     globs.root_bones = bone_groups_tmp
     globs.root_bones_choices = choices
 
-    return bpy.types.Object.Enum
+    return choices
 
 
 @register_wrap

--- a/tools/translations.py
+++ b/tools/translations.py
@@ -79,8 +79,7 @@ def get_languages_list(self, context):
         # 3. will be shown in the hover description (below description)
         choices.append((language, language, language))
 
-    bpy.types.Object.Enum = choices
-    return bpy.types.Object.Enum
+    return choices
 
 
 def update_ui(self, context):

--- a/ui/decimation.py
+++ b/ui/decimation.py
@@ -125,7 +125,7 @@ class DecimationPanel(ToolPanel, bpy.types.Panel):
                 row.operator(Decimation.AddMeshButton.bl_idname, icon=globs.ICON_ADD)
                 col.separator()
 
-                if context.scene.add_mesh == '':
+                if Common.is_enum_empty(context.scene.add_mesh):
                     row = col.row(align=True)
                     col.label(text=t('DecimationPanel.warn.noDecimation'), icon='ERROR')
 

--- a/ui/visemes.py
+++ b/ui/visemes.py
@@ -91,15 +91,18 @@ class VisemePanel(ToolPanel, bpy.types.Panel):
         row = col.row(align=True)
         row.scale_y = 1.1
         row.label(text=t('Scene.mouth_a.label')+":")
-        row.operator(SearchMenuOperatorMouthA.bl_idname, text = context.scene.mouth_a, icon='SHAPEKEY_DATA')
+        mouth_a_text = 'None' if Common.is_enum_empty(context.scene.mouth_a) else context.scene.mouth_a
+        row.operator(SearchMenuOperatorMouthA.bl_idname, text=mouth_a_text, icon='SHAPEKEY_DATA')
         row = col.row(align=True)
         row.scale_y = 1.1
         row.label(text=t('Scene.mouth_o.label')+":")
-        row.operator(SearchMenuOperatorMouthO.bl_idname, text = context.scene.mouth_o, icon='SHAPEKEY_DATA')
+        mouth_o_text = 'None' if Common.is_enum_empty(context.scene.mouth_o) else context.scene.mouth_o
+        row.operator(SearchMenuOperatorMouthO.bl_idname, text=mouth_o_text, icon='SHAPEKEY_DATA')
         row = col.row(align=True)
         row.scale_y = 1.1
         row.label(text=t('Scene.mouth_ch.label')+":")
-        row.operator(SearchMenuOperatorMouthCH.bl_idname, text = context.scene.mouth_ch, icon='SHAPEKEY_DATA')
+        mouth_ch_text = 'None' if Common.is_enum_empty(context.scene.mouth_ch) else context.scene.mouth_ch
+        row.operator(SearchMenuOperatorMouthCH.bl_idname, text=mouth_ch_text, icon='SHAPEKEY_DATA')
 
         col.separator()
         row = col.row(align=True)

--- a/updater.py
+++ b/updater.py
@@ -12,6 +12,7 @@ from threading import Thread
 from collections import OrderedDict
 from bpy.app.handlers import persistent
 from .tools.translations import t
+from .tools.common import wrap_dynamic_enum_items
 
 no_ver_check = False
 fake_update = False
@@ -744,8 +745,7 @@ def get_version_list(self, context):
         for version in version_list.keys():
             choices.append((version, version, version))
 
-    bpy.types.Object.Enum = choices
-    return bpy.types.Object.Enum
+    return choices
 
 
 def get_user_preferences():
@@ -944,7 +944,7 @@ def register(bl_info, dev_branch, version_str):
     bpy.types.Scene.cats_updater_version_list = bpy.props.EnumProperty(
         name=t('bpy.types.Scene.cats_updater_version_list.label'),
         description=t('bpy.types.Scene.cats_updater_version_list.desc'),
-        items=get_version_list
+        items=wrap_dynamic_enum_items(get_version_list, 'cats_updater_version_list', sort=False)
     )
     bpy.types.Scene.cats_update_action = bpy.props.EnumProperty(
         name=t('bpy.types.Scene.cats_update_action.label'),


### PR DESCRIPTION
There are a bunch of `EnumProperty` properties that use a function to get the list of items for that property. An issue occurs when the currently selected item in the UI is the last in the list of items and then the object/armature/shapekey/etc. corresponding to that item is deleted. The index of the selected item remains the same, but the list of items shrinks such that the index is now out of bounds. This causes a warning to be printed in the console each time UI attempts to draw the property or the property is otherwise accessed. Additionally, attempting to get the value of the `EnumProperty` that has gone out of bounds will return `''` which may not be a valid or expected value (in Blender 2.79, if there is an item at index 0, it returns that instead).

This PR adds a wrapper for the `items` functions that are used in `EnumProperty`s. When the property is accessed, if the index of the property is out of bounds, it temporarily adds duplicates of the last element in the list of items until the index is in bounds again and then tries to set the index such that it is back in bounds (ignoring the temporarily added duplicates). Often, getting the list of items occurs during UI drawing, which is prevented from modifying properties, so changing the index to be back in bounds is then deferred and run a little bit later.

By fixing out-of-bounds indices in this way, the `Common.reset_context_scenes` function is no longer necessary as the properties will automatically be set to valid values whenever they are accessed.

The wrapper also ensures that the list of items is never empty and includes the commonly used method of sorting the list of items to avoid repeated code. The sorting can be disabled via the `sort` argument and the wrapper can be forced to not run in-place with the `in_place` argument.

As part of ensuring the list of items is never empty, there is a constant identifier, `Common._empty_enum_identifier`, used to indicate whether an EnumProperty is empty. `is_enum_empty` and `is_enum_non_empty` functions have been added for checking against the constant identifier. The latter isn't really needed since the former can be negated, but I think it makes code more readable to have it.

As Blender 2.79 does not have Application Timers (`bpy.app.timers`) the temporarily added duplicate items will continue to be added every time the property is accessed until the property is accessed outside of UI drawing. To users, this will let them see the all the temporary duplicates in the UI, but upon closing the UI dropdown/search it will automatically fix itself as that causes the property to be accessed outside of UI drawing. To code that reads the value of the property, there will be no perceivable difference as the temporary duplicate items have the same identifier as the last element of the items. I did figure out a way to use a separate Thread for 2.79 instead of Application Timers, but I don't think it would be safe to use.
Here I have deleted `Armature.002` so there is now a duplicate `Armature.001` in the list, upon closing the drop down, the duplicate will disappear as that will cause the index to be set back in-bounds.
![image](https://user-images.githubusercontent.com/495015/158071738-8b599df8-5d4c-4dbd-8e1e-ed463f4e18ae.png)


The wrapper also works around a known bug with EnumProperty properties:
> There is a known bug with using a callback, Python must keep a reference to the strings returned by the callback or Blender will misbehave or even crash.

This bug causes UI text to be garbled as presumably it's reading random memory which is probably why it theoretically could cause Blender to crash. This issue isn't very visible when displaying an `EnumProperty` in UI via `row.prop` as the currently selected choice and list of choices displays correctly without any fixes, however the descriptions for the choices are almost always garbled. If instead, an `EnumProperty` is displayed in a UI via `row.props_enum`, the issue becomes very visible: the currently selected choice becomes garbled when moving objects in the scene around and the unselected choices are almost always garbled.
Garbled description text example:
![image](https://user-images.githubusercontent.com/495015/158073145-cd2aeb89-99ee-4831-b39a-802d8a21d5e2.png)
The wrapper keeps references by interning all the strings in the list of items and then caching the strings into a dictionary for each property path.

I guess that all the assignments to `bpy.types.Object.Enum` in the various `items` functions was an attempt to workaround this known bug. Unfortunately, all this does is keep a reference to the list of the last called items function, when it's the strings within all the items lists that Python must keep references to. These assignments have been removed.

I did look at the possibility of replacing `EnumProperty`s with `PointerProperty`s, but this didn't seem like a good idea for some of the properties as a `PointerProperty` can keep reference to an Object/Shapekey/etc even if the `PointerProperty`'s `poll` function says that the Object/Shapekey/etc is no longer valid and can keep reference to Objects and possibly other types that have been deleted from the scene, which also prevents said deleted Objects from being considered Orphan Data. Maybe these issues could be worked around, but it's not something I've looked into any further than this.

While Cats does not currently have any dynamic `EnumProperty`s within a `PropertyGroup` or `CollectionProperty`, I did make sure that the wrapper also works with `EnumProperty`s nested in either.

The main limitation of this wrapper is that it only works for properties that are owned by a Scene object as the scheduled task needs to be able to get the owner of the property to fix by the owner's name since keeping reference to the owner is a bad idea as the owner could be deleted prior to the scheduled task running. Fortunately, all of Cats' `EnumProperty`s are owned by a scene.

---

If you want to see the out-of-bounds issue yourself or compare behaviour with this PR (show the system console if you want to see the warning spam):
1. Create 3 armatures (3 are needed to fully show this issue because the part of the UI is hidden when there is only 1 armature)
2. Select the bottom armature in the Cats UI (above the Fix Model button)
3. Delete that armature from the scene
4. The `armature` property of the scene is now out of bounds

An alternative:
1. Open the Visemes section of the CATS UI
2. Select a mesh with shape keys in the UI
3. Delete all the shape key from that mesh
4. The `mouth_a`, `mouth_o` and `mouth_ch` properties of the scene are now out of bounds (in this case because the list of shape keys is now empty)