### PR TITLE
Rewrite PoseToRest operator to correctly affect shape keys with any pose

### DIFF
--- a/resources/translations.csv
+++ b/resources/translations.csv
@@ -258,13 +258,7 @@ PoseNamePopup.label,Give this shapekey a name:,このシェイプキーに名前
 PoseNamePopup.desc,Sets the shapekey name. Press anywhere outside to skip,,쉐이프키 이름을 설정합니다. 스킵하려면 아무 곳이나 누르세요.
 PoseNamePopup.success,Pose successfully saved as shape key.,,포즈가 성공적으로 쉐이프키로 저장되었습니다.
 PoseToRest.label,Apply as Rest Pose,レストポーズとして適用する,새로운 기본자세로 적용
-PoseToRest.desc,"This applies the current pose position as the new rest position.
-
-If you scale the bones equally on each axis the shape keys will be scaled correctly as well!
-WARNING: This can have unwanted effects on shape keys, so be careful when modifying the head with this",,"이것은 현재 포즈를 새로운 기본 포즈로 적용합니다.
-
-만약 당신이 뼈들의 스케일을 각 축마다 동일하게 조절했다면 쉐이프키들 또한 올바르게 적용될 것입니다!
-경고: 이것은 쉐이프키에 원치 않는 영향을 줄 수 있기 때문에, 이걸로 머리를 수정할 경우 조심하세요."
+PoseToRest.desc,This applies the current pose position as the new rest position.,,이것은 현재 포즈를 새로운 기본 포즈로 적용합니다.
 PoseToRest.success,Pose successfully applied as rest pose.,,포즈가 성공적으로 기본자세로 적용되었습니다.
 JoinMeshes.label,Join Meshes,メッシュに参加する,메쉬 통합
 JoinMeshes.desc,"Joins all meshes of this model together.

--- a/tools/armature_manual.py
+++ b/tools/armature_manual.py
@@ -28,6 +28,7 @@ import bpy
 import operator
 import math
 import webbrowser
+import numpy as np
 from mathutils.geometry import intersect_point_line
 
 from . import common as Common
@@ -390,103 +391,41 @@ class PoseToRest(bpy.types.Operator):
     def execute(self, context):
         saved_data = Common.SavedData()
 
-        armature = Common.get_armature()
-        Common.set_active(armature)
-        scales = {}
-
-        # Find out how much each bone is scaled
-        for bone in armature.pose.bones:
-            scale_x = bone.scale[0]
-            scale_y = bone.scale[1]
-            scale_z = bone.scale[2]
-
-            if armature.data.bones.get(bone.name).use_inherit_scale:
-                def check_parent(child, scale_x_tmp, scale_y_tmp, scale_z_tmp):
-                    if child.parent:
-                        parent = child.parent
-                        scale_x_tmp *= parent.scale[0]
-                        scale_y_tmp *= parent.scale[1]
-                        scale_z_tmp *= parent.scale[2]
-
-                        if armature.data.bones.get(parent.name).use_inherit_scale:
-                            scale_x_tmp, scale_y_tmp, scale_z_tmp = check_parent(parent, scale_x_tmp, scale_y_tmp,
-                                                                                 scale_z_tmp)
-
-                    return scale_x_tmp, scale_y_tmp, scale_z_tmp
-
-                scale_x, scale_y, scale_z = check_parent(bone, scale_x, scale_y, scale_z)
-
-            if scale_x == scale_y == scale_z != 1:
-                scales[bone.name] = scale_x
-
-        pose_to_shapekey('PoseToRest')
-
-        bpy.ops.pose.armature_apply()
-
-        for mesh in Common.get_meshes_objects():
-            Common.unselect_all()
-            Common.set_active(mesh)
-
-            mesh.active_shape_key_index = len(mesh.data.shape_keys.key_blocks) - 1
-            bpy.ops.cats_shapekey.shape_key_to_basis()
-
-            # Remove old basis shape key from shape_key_to_basis operation
-            for index in range(len(mesh.data.shape_keys.key_blocks) - 1, 0, -1):
-                mesh.active_shape_key_index = index
-                if 'PoseToRest - Reverted' in mesh.active_shape_key.name:
-                    bpy.ops.object.shape_key_remove(all=False)
-
-            mesh.active_shape_key_index = 0
-
-            # Find out which bones scale which shapekeys and set it to the highest scale
-            print('\nSCALED BONES:')
-            shapekey_scales = {}
-            for bone_name, scale in scales.items():
-                print(bone_name, scale)
-                vg = mesh.vertex_groups.get(bone_name)
-                if not vg:
-                    continue
-
-                for vertex in mesh.data.vertices:
-                    for g in vertex.groups:
-                        if g.group == vg.index and g.weight == 1:
-                            for i, shapekey in enumerate(mesh.data.shape_keys.key_blocks):
-                                if i == 0:
-                                    continue
-
-                                if shapekey.data[vertex.index].co != mesh.data.shape_keys.key_blocks[0].data[
-                                    vertex.index].co:
-                                    if shapekey.name in shapekey_scales:
-                                        shapekey_scales[shapekey.name] = max(shapekey_scales[shapekey.name], scale)
-                                    else:
-                                        shapekey_scales[shapekey.name] = scale
-                            break
-
-            # Mix every shape keys with itself with the slider set to the new scale
-            for index in range(0, len(mesh.data.shape_keys.key_blocks)):
-                mesh.active_shape_key_index = index
-                shapekey = mesh.active_shape_key
-                if shapekey.name in shapekey_scales:
-                    print('Fixed shapekey', shapekey.name)
-                    shapekey.slider_max = min(shapekey_scales[shapekey.name], 10)
-                    shapekey.value = shapekey.slider_max
-                    mesh.shape_key_add(name=shapekey.name + '-New', from_mix=True)
-                    shapekey.value = 0
-
-            # Remove all the old shapekeys
-            for index in reversed(range(0, len(mesh.data.shape_keys.key_blocks))):
-                mesh.active_shape_key_index = index
-                shapekey = mesh.active_shape_key
-                if shapekey.name in shapekey_scales:
-                    bpy.ops.object.shape_key_remove(all=False)
-
-            # Fix the names of the new shapekeys
-            for index, shapekey in enumerate(mesh.data.shape_keys.key_blocks):
-                if shapekey and shapekey.name.endswith('-New'):
-                    shapekey.name = shapekey.name[:-4]
-
-            # Repair important shape key order
-            Common.repair_shapekey_order(mesh.name)
+        armature_obj = Common.get_armature()
+        mesh_objs = Common.get_meshes_objects(armature_name=armature_obj.name)
+        for mesh_obj in mesh_objs:
+            me = mesh_obj.data
+            if me:
+                if me.shape_keys and me.shape_keys.key_blocks:
+                    # The mesh has shape keys
+                    shape_keys = me.shape_keys
+                    key_blocks = shape_keys.key_blocks
+                    if len(key_blocks) == 1:
+                        # The mesh only has a basis shape key, so we can remove it and then add it back afterwards
+                        # Get basis shape key
+                        basis_shape_key = key_blocks[0]
+                        # Save the name of the basis shape key
+                        original_basis_name = basis_shape_key.name
+                        # Remove the basis shape key so there are now no shape keys
+                        mesh_obj.shape_key_remove(basis_shape_key)
+                        # Apply the pose to the mesh
+                        PoseToRest.apply_armature_to_mesh_with_no_shape_keys(armature_obj, mesh_obj)
+                        # Add the basis shape key back with the same name as before
+                        mesh_obj.shape_key_add(name=original_basis_name)
+                    else:
+                        # Apply the pose to the mesh, taking into account the shape keys
+                        PoseToRest.apply_armature_to_mesh_with_shape_keys(armature_obj, mesh_obj, context.scene)
+                else:
+                    # The mesh doesn't have shape keys, so we can easily apply the pose to the mesh
+                    PoseToRest.apply_armature_to_mesh_with_no_shape_keys(armature_obj, mesh_obj)
+        # Once the mesh and shape keys (if any) have been applied, the last step is to apply the current pose of the
+        # bones as the new rest pose.
+        #
+        # From the poll function, armature_obj must already be in pose mode, but it's possible it might not be the
+        # active object e.g., the user has multiple armatures opened in pose mode, but a different armature is currently
+        # active. We can use an operator override to tell the operator to treat armature_obj as if it's the active
+        # object even if it's not, skipping the need to actually set armature_obj as the active object.
+        bpy.ops.pose.armature_apply({'active_object': armature_obj})
 
         # Stop pose mode after operation
         bpy.ops.cats_manual.stop_pose_mode()
@@ -495,6 +434,122 @@ class PoseToRest(bpy.types.Operator):
 
         self.report({'INFO'}, t('PoseToRest.success'))
         return {'FINISHED'}
+
+    @staticmethod
+    def apply_armature_to_mesh_with_no_shape_keys(armature_obj, mesh_obj):
+        armature_mod = mesh_obj.modifiers.new('PoseToRest', 'ARMATURE')
+        armature_mod.object = armature_obj
+        # In the unlikely case that there was already a modifier with the same name as the new modifier, the new
+        # modifier will have ended up with a different name
+        mod_name = armature_mod.name
+        # Context override to let us run the modifier operators on mesh_obj, even if it's not the active object
+        context_override = {'object': mesh_obj}
+        # Moving the modifier to the first index will prevent an Info message about the applied modifier not being
+        # first and potentially having unexpected results.
+        if bpy.app.version >= (2, 90, 0):
+            # modifier_move_to_index was added in Blender 2.90
+            bpy.ops.object.modifier_move_to_index(context_override, modifier=mod_name, index=0)
+        else:
+            # The newly created modifier will be at the bottom of the list
+            armature_mod_index = len(mesh_obj.modifiers) - 1
+            # Move the modifier up until it's at the top of the list
+            for _ in range(armature_mod_index):
+                bpy.ops.object.modifier_move_up(context_override, modifier=mod_name)
+        bpy.ops.object.modifier_apply(context_override, modifier=mod_name)
+
+    @staticmethod
+    def apply_armature_to_mesh_with_shape_keys(armature_obj, mesh_obj, scene):
+        # The active shape key will be changed, so save the current active index, so it can be restored afterwards
+        old_active_shape_key_index = mesh_obj.active_shape_key_index
+
+        # Shape key pinning shows the active shape key in the viewport without blending; effectively what you see when
+        # in edit mode. Combined with an armature modifier, we can use this to figure out the correct positions for all
+        # the shape keys.
+        # Save the current value, so it can be restored afterwards.
+        old_show_only_shape_key = mesh_obj.show_only_shape_key
+        mesh_obj.show_only_shape_key = True
+
+        # Temporarily remove vertex_groups from and disable mutes on shape keys because they affect pinned shape keys
+        me = mesh_obj.data
+        shape_key_vertex_groups = []
+        shape_key_mutes = []
+        key_blocks = me.shape_keys.key_blocks
+        for shape_key in key_blocks:
+            shape_key_vertex_groups.append(shape_key.vertex_group)
+            shape_key.vertex_group = ''
+            shape_key_mutes.append(shape_key.mute)
+            shape_key.mute = False
+
+        # Temporarily disable all modifiers from showing in the viewport so that they have no effect
+        mods_to_reenable_viewport = []
+        for mod in mesh_obj.modifiers:
+            if mod.show_viewport:
+                mod.show_viewport = False
+                mods_to_reenable_viewport.append(mod)
+
+        # Temporarily add a new armature modifier
+        armature_mod = mesh_obj.modifiers.new('PoseToRest', 'ARMATURE')
+        armature_mod.object = armature_obj
+
+        # cos are xyz positions and get flattened when using the foreach_set/foreach_get functions, so the array length
+        # will be 3 times the number of vertices
+        co_length = len(me.vertices) * 3
+        # We can re-use the same array over and over
+        eval_verts_cos_array = np.empty(co_length, dtype=np.single)
+
+        if Common.version_2_79_or_older():
+            def get_eval_cos_array():
+                # Create a new mesh with modifiers and shape keys applied
+                evaluated_mesh = mesh_obj.to_mesh(scene, True, 'PREVIEW')
+
+                # Get the cos of the vertices from the evaluated mesh
+                evaluated_mesh.vertices.foreach_get('co', eval_verts_cos_array)
+                # Delete the newly created mesh
+                bpy.data.meshes.remove(evaluated_mesh)
+                return eval_verts_cos_array
+        else:
+            # depsgraph lets us evaluate objects and get their state after the effect of modifiers and shape keys
+            depsgraph = None
+            evaluated_mesh_obj = None
+
+            def get_eval_cos_array():
+                nonlocal depsgraph
+                nonlocal evaluated_mesh_obj
+                # Get the depsgraph and evaluate the mesh if we haven't done so already
+                if depsgraph is None or evaluated_mesh_obj is None:
+                    depsgraph = bpy.context.evaluated_depsgraph_get()
+                    evaluated_mesh_obj = mesh_obj.evaluated_get(depsgraph)
+                else:
+                    # If we already have the depsgraph and evaluated mesh, in order for the change to the active shape
+                    # key to take effect, the depsgraph has to be updated
+                    depsgraph.update()
+                # Get the cos of the vertices from the evaluated mesh
+                evaluated_mesh_obj.data.vertices.foreach_get('co', eval_verts_cos_array)
+                return eval_verts_cos_array
+
+        for i, shape_key in enumerate(key_blocks):
+            # As shape key pinning is enabled, when we change the active shape key, it will change the state of the mesh
+            mesh_obj.active_shape_key_index = i
+            # The cos of the vertices of the evaluated mesh include the effect of the pinned shape key and all the
+            # modifiers (in this case, only the armature modifier we added since all the other modifiers are disabled in
+            # the viewport).
+            # This combination gives the same effect as if we'd applied the armature modifier to a mesh with the same
+            # shape as the active shape key, so we can simply set the shape key to the evaluated mesh position.
+            #
+            # Get the evaluated cos
+            evaluated_cos = get_eval_cos_array()
+            # And set the shape key to those same cos
+            shape_key.data.foreach_set('co', evaluated_cos)
+
+        # Restore temporarily changed attributes and remove the added armature modifier
+        for mod in mods_to_reenable_viewport:
+            mod.show_viewport = True
+        mesh_obj.modifiers.remove(armature_mod)
+        for shape_key, vertex_group, mute in zip(me.shape_keys.key_blocks, shape_key_vertex_groups, shape_key_mutes):
+            shape_key.vertex_group = vertex_group
+            shape_key.mute = mute
+        mesh_obj.active_shape_key_index = old_active_shape_key_index
+        mesh_obj.show_only_shape_key = old_show_only_shape_key
 
 
 @register_wrap


### PR DESCRIPTION
I have rewritten the PoseToRest operator (Apply as Rest Pose) to work with any pose when there are shape keys. You can rotate, translate and scale pose bones however you want and the shape keys will be modified correctly (like how you see them in Blender when you're in pose mode and also have some shape keys active). It also works with shape keys that are relative to a shape key other than the Basis.

Effectively, for each shape key, it finds what the effect of applying the armature modifier would be if the mesh straight up was that shape key.

Shape keys with the old implementation work fine with moved bones (since they don't affect the differences between shape keys) and seem to work for uniformly scaled bones, but don't work at all with rotated bones.

From my tests on a VRChat avatar, it seems to run marginally faster than the old implementation, probably not enough to be noticeable in most cases so I didn't go in-depth on the performance comparison. The one larger test I did I added a really subdivided cube to the head mesh to get the mesh to just over 100,000 vertices with 93 shape keys and ended up with the new implementation being almost a second faster (about 7 seconds compared to 8 seconds). The old implementation has to do stuff with bones and vertex groups so it's probably going to scale a bit differently to the new implementation anyway.

Blender 2.79 has a slight difference in the implementation due to its API differences, but it seems to run in about the same amount of time as 2.80+.