### PR TITLE
Fix implicit string concatenation found in list

### DIFF
--- a/tools/armature_bones.py
+++ b/tools/armature_bones.py
@@ -436,8 +436,8 @@ bone_rename['Spine'] = [  # This is a list of all the spine and chest bones. The
     'Spine_Upper_1',
     'Spine_Upper_2',
 
-    'J_SpineLower'
-    'J_SpineUpper'
+    'J_SpineLower',
+    'J_SpineUpper',
 
     'Abdomen',
 


### PR DESCRIPTION
`J_SpineLower` and `J_SpineUpper` contained in the `bone_rename['Spine']` was automatically concatenate and treated as `J_SpineLowerJ_SpineUpper`. Prevent it by adding `,`.