### PR TITLE
Fix error importing .zip with file/directory names containing cp437 characters not in cp932

### DIFF
--- a/tools/importer.py
+++ b/tools/importer.py
@@ -379,7 +379,7 @@ def get_zip_content(self, context):
 def encode_str(s):
     try:
         s = s.encode('cp437').decode('cp932')
-    except UnicodeEncodeError:
+    except (UnicodeEncodeError, UnicodeDecodeError):
         pass
     return s
 


### PR DESCRIPTION
A user on discord had the following error trying to import a a .zip file:
![image](https://user-images.githubusercontent.com/495015/170845496-027a1ec5-d009-404d-8db4-c1fb6f42c06c.png)
It's possible that a file/directory name read from a .zip contains characters that are present in Code Page 437 (DOS Latin US [and other names]) that are not present in Code Page 932 (Shift JIS), which can cause a file/directory name to encode to cp437 fine, but then fail to decode to cp932.

For example, `é` encodes to cp437 fine, but the same encoded bytes in cp932 correspond to a multibyte sequence, where if the next (or previous) byte(s) aren't a specific value, a `UnicodeDecodeError` will be raised.

This change to also catch the `UnicodeDecodeError` that can occur during the `decode('cp932')` step fixes the error preventing the import of the .zip.