### PR TITLE
Fix mesh's vertices and basis shapekey desync in pose_to_rest and shape_key_to_basis operators

### DIFF
--- a/tools/armature_manual.py
+++ b/tools/armature_manual.py
@@ -540,6 +540,11 @@ class PoseToRest(bpy.types.Operator):
             evaluated_cos = get_eval_cos_array()
             # And set the shape key to those same cos
             shape_key.data.foreach_set('co', evaluated_cos)
+            # If it's the basis shape key, we also have to set the mesh vertices to match, otherwise the two will be
+            # desynced until Edit mode has been entered and exited, which can cause odd behaviour when creating shape
+            # keys with from_mix=False or when removing all shape keys.
+            if i == 0:
+                mesh_obj.data.vertices.foreach_set('co', evaluated_cos)
 
         # Restore temporarily changed attributes and remove the added armature modifier
         for mod in mods_to_reenable_viewport:

--- a/tools/shapekey.py
+++ b/tools/shapekey.py
@@ -467,6 +467,12 @@ class ShapeKeyApplier(bpy.types.Operator):
                 key_block.data.foreach_get('co', temp_co_array)
                 key_block.data.foreach_set('co', np.add(temp_co_array, temp_co_array2, out=temp_co_array))
 
+        # Update mesh vertices to avoid basis shape key and mesh vertices being desynced until Edit mode has been
+        # entered and exited, which can cause odd behaviour when creating shape keys with from_mix=False or when
+        # removing all shape keys.
+        data.shape_keys.reference_key.data.foreach_get('co', temp_co_array)
+        data.vertices.foreach_set('co', temp_co_array)
+
 
 def addToShapekeyMenu(self, context):
     self.layout.separator()


### PR DESCRIPTION
Without this fix, if you immediately add a new shape key with `from_mix=False` after running either operator, the newly created shape key will be created based on the mesh's vertices which haven't been affected by the operator.
Similarly, removing all shape keys immediately after running either operator will revert the mesh back to the shape of the mesh's vertices.
The issue can be worked around until fixed by going into edit mode and back out because this causes Blender to re-sync the mesh's vertices to match the basis shape key.