### PR TITLE
Fix using View3DShading.render_pass on old Blender versions without it

### DIFF
--- a/tools/armature.py
+++ b/tools/armature.py
@@ -1347,4 +1347,5 @@ def set_material_shading():
                     space.shading.studio_light = 'forest.exr'
                     space.shading.studiolight_rotate_z = 0.0
                     space.shading.studiolight_background_alpha = 0.0
-                    space.shading.render_pass = 'COMBINED'
+                    if bpy.app.version >= (2, 82):
+                        space.shading.render_pass = 'COMBINED'


### PR DESCRIPTION
As it doesn't exist in versions < 2.82 it raises an error in those versions. It appears to have been added in 2.82 (it's first present in the 2.82 documentation) alongside the ability to create custom cycles render passes.