### PR TITLE
Fix Combine Same Materials on 2.80 and older and related issues + Faulty UV fix optimisation

### DIFF
--- a/tools/common.py
+++ b/tools/common.py
@@ -1769,13 +1769,13 @@ def get_bone_orientations(armature):
 
 
 def clean_material_names(mesh):
-    for j, mat in enumerate(mesh.material_slots):
-        if mat.name.endswith('.001'):
-            mesh.active_material_index = j
-            mesh.active_material.name = mat.name[:-4]
-        if mat.name.endswith(('. 001', ' .001')):
-            mesh.active_material_index = j
-            mesh.active_material.name = mat.name[:-5]
+    for mat_slot in mesh.material_slots:
+        mat = mat_slot.material
+        if mat:
+            if mat.name.endswith(('. 001', ' .001')):
+                mat.name = mat.name[:-5]
+            elif mat.name.endswith('.001'):
+                mat.name = mat.name[:-4]
 
 
 def mix_weights(mesh, vg_from, vg_to, mix_strength=1.0, mix_mode='ADD', delete_old_vg=True):

--- a/tools/importer.py
+++ b/tools/importer.py
@@ -796,15 +796,16 @@ class ExportGmodPlayermodel(bpy.types.Operator):
             objname = obj.name
             if bpy.data.objects[objname].type == "MESH":
                 print("lowercasing material name for gmod for object "+objname)
-                for material in bpy.data.objects[objname].material_slots:
-                    mat = material.material
-                    sanitized_material_name = ""
-                    for i in mat.name.lower():
-                        if i.isalnum() or i == "_":
-                            sanitized_material_name += i
-                        else:
-                            sanitized_material_name += "_"
-                    mat.name = sanitized_material_name
+                for mat_slot in bpy.data.objects[objname].material_slots:
+                    mat = mat_slot.material
+                    if mat:
+                        sanitized_material_name = ""
+                        for i in mat.name.lower():
+                            if i.isalnum() or i == "_":
+                                sanitized_material_name += i
+                            else:
+                                sanitized_material_name += "_"
+                        mat.name = sanitized_material_name
         
         
         print("zeroing transforms and then scaling to gmod scale, then applying transforms.")


### PR DESCRIPTION
This is patch for a few issues with the Combine Same Materials part of Fix Model:
1. This fixes it not running on Blender 2.80 and older as `bpy.ops.object.material_slot_remove_unused` does not exist on those versions.
1. Additionally, I found that Combine Materials was being called for every mesh fixed, despite the fact that Combine Same Materials operates on all of the meshes so only needs to be called once. It has been moved outside of the loop that iterates through meshes.
1. I have moved the call to add_principled_shader after Combine Materials as otherwise, when baking ambient and diffuse mmd color into the mmd base tex, even if the colors and base tex are the same, it will result in a different baked image, causing the material hash generated in Combine Materials to be different, despite the materials otherwise being the same. This was effectively preventing Combine Materials from doing anything with mmd materials.
1. I have optimised Combine Materials to use OBJECT mode and foreach_get/set to re-assign material indices of polygons.
    * The stateful behaviour of assigning material hashes to a dictionary (`self.combined_tex`) before iterating the mesh objects has been replaced with producing the dictionary while iterating, this is why the material hash generation has been moved to its own function that takes a material argument instead of one function that generates material hashes for all the materials of all the meshes and stores them in `self.combined_tex`.
1. While they're very unlikely to be used, it's possible that a material in Blender 2.80+ does not use nodes, I have added a simple material hash for such materials so that they won't be combined with empty material slots. The generation of material hashes is otherwise unchanged.
1. common.clean_material_names is called from Combine Same Materials and I noticed that it for some reason changes the active material and then gets the active material when the material can be accessed directly, which is what I have changed it to do. I have also flipped the order of the name replacement, since any material name ending in `' .001'` would have already been modified due to it ending in `'.001'`.
1. Since common.clean_material_names and some of the other code near my modifications wasn't checking for the case where a material slot is empty, I went through all other places I could find that weren't checking if the slots were empty before trying to use the slot's material and updated them with checks, since running any of these with empty material slots would always result in an error being raised.

-----
Since it was in the middle of other code I was modifying, I also optimised the part of Fix Model that fixes faulty uv coordinates and added plus and minus infinity to the values it considers faulty. It was also resetting the count of fixed uv coordinates with each mesh iterated, so I've fixed that too. It is included as a separate commit because it's not really related to any of the other changes.

-----
I have tested on Blender 2.80, 2.90.1, 2.93.9 and 3.2.0. The development branch does not load on 2.79 so I could not test it there.
When testing against 2.80 I included the change from https://github.com/absolute-quantum/cats-blender-plugin/pull/481