### PR TITLE
Add option to make shapekeys cleanup optional when merging armatures

### DIFF
--- a/extentions.py
+++ b/extentions.py
@@ -168,6 +168,12 @@ def register():
         default=True
     )
 
+    Scene.merge_armatures_remove_empty_shapekeys = BoolProperty(
+        name=t('Scene.merge_armatures_remove_empty_shapekeys.label'),
+        description=t('Scene.merge_armatures_remove_empty_shapekeys.desc'),
+        default=True
+    )
+
     # Decimation
     Scene.decimation_mode = EnumProperty(
         name=t('Scene.decimation_mode.label'),

--- a/resources/translations.csv
+++ b/resources/translations.csv
@@ -884,6 +884,11 @@ Not checking this will always apply transforms",,
 Scene.merge_armatures_remove_zero_weight_bones.label,Remove Zero Weight Bones,ゼロウェイトボーンを削除する,제로 웨이트 본 제거
 Scene.merge_armatures_remove_zero_weight_bones.desc,"Cleans up the bones hierarchy, deleting all bones that don't directly affect any vertices.
 Uncheck this if bones or vertex groups that you want to keep got deleted",,
+Scene.merge_armatures_remove_empty_shapekeys.label,Remove empty shapekeys,空のシェイプキーを削除する
+Scene.merge_armatures_remove_empty_shapekeys.desc,"Remove empty shapekeys during shapekeys cleanup.
+
+If this is checked, CATS removes all empty shapekeys, including all empty visemes.
+If this is unchecked, CATS keeps all shapekeys when it merges armatures. This is useful for keeping visemes needed for the vrc avatar descriptor",,
 Scene.decimation_mode.label,Decimation Mode,単純化モード,
 Scene.decimation_mode.desc,Decimation Mode,,
 Scene.decimation_mode.smart.label,Smart,スマート,

--- a/tools/armature_custom.py
+++ b/tools/armature_custom.py
@@ -331,10 +331,11 @@ def merge_armatures(base_armature_name, merge_armature_name, mesh_only, mesh_nam
     armature = Common.get_armature(armature_name=base_armature_name)
 
     # Clean up shape keys
-    for mesh_base in meshes_base:
-        Common.clean_shapekeys(mesh_base)
-    for mesh_merge in meshes_merge:
-        Common.clean_shapekeys(mesh_merge)
+    if bpy.context.scene.merge_armatures_remove_empty_shapekeys:
+        for mesh_base in meshes_base:
+            Common.clean_shapekeys(mesh_base)
+        for mesh_merge in meshes_merge:
+            Common.clean_shapekeys(mesh_merge)
 
     # Join the meshes
     if bpy.context.scene.merge_armatures_join_meshes:

--- a/ui/custom.py
+++ b/ui/custom.py
@@ -59,6 +59,10 @@ class CustomPanel(ToolPanel, bpy.types.Panel):
             row.prop(context.scene, 'merge_armatures_remove_zero_weight_bones')
 
             row = col.row(align=True)
+            row.scale_y = 0.95
+            row.prop(context.scene, 'merge_armatures_remove_empty_shapekeys')
+
+            row = col.row(align=True)
             row.scale_y = 1.05
             row.prop(context.scene, 'merge_armature_into', text=t('CustomPanel.mergeInto'), icon=globs.ICON_MOD_ARMATURE)
             row = col.row(align=True)


### PR DESCRIPTION
This makes cleaning up shapekeys optional when merging armatures. CATS does this every time you use the merge armatures tool, but it ignores common empty visemes used for the VRC avatar descriptor in Unity.

In my example, the shapekeys VRC.v_sil and VRC.v_PP were removed by CATS because they were empty, causing LipSync not to work.

This PR adds the option to skip the cleanup and keep those visemes or other important shapekeys that should not be removed but must remain empty.

![image](https://user-images.githubusercontent.com/53810001/175128567-720b0bfd-5441-4521-a9e2-f9ad9c647f56.png)