### PR TITLE
Fix using EditBones outside of EDIT mode in create_eye_tracking

### DIFF
--- a/tools/eyetracking.py
+++ b/tools/eyetracking.py
@@ -166,6 +166,15 @@ class CreateEyesButton(bpy.types.Operator):
         fix_eye_position(context, old_eye_left, new_left_eye, head, False)
         fix_eye_position(context, old_eye_right, new_right_eye, head, True)
 
+        # The names may be needed later, but references to edit bones become invalid once EDIT mode has been left, so
+        # the names need to be assigned to variables before switching to OBJECT mode
+        new_right_eye_name = new_right_eye.name
+        old_eye_left_name = old_eye_left.name
+        old_eye_right_name = old_eye_right.name
+        head_name = head.name
+        # Delete the variables that are about to become invalid to guarantee that they aren't accidentally still used
+        del new_right_eye, new_left_eye, old_eye_right, old_eye_left, head
+
         # Switch to mesh
         Common.set_active(self.mesh)
         Common.switch('OBJECT')
@@ -175,8 +184,8 @@ class CreateEyesButton(bpy.types.Operator):
 
         # Copy the existing eye vertex group to the new one if eye movement is activated
         if not context.scene.disable_eye_movement:
-            self.copy_vertex_group(old_eye_left.name, 'LeftEye')
-            self.copy_vertex_group(old_eye_right.name, 'RightEye')
+            self.copy_vertex_group(old_eye_left_name, 'LeftEye')
+            self.copy_vertex_group(old_eye_right_name, 'RightEye')
         else:
             # Remove the vertex groups if no blink is enabled
             bones = ['LeftEye', 'RightEye']
@@ -211,9 +220,9 @@ class CreateEyesButton(bpy.types.Operator):
         Common.sort_shape_keys(mesh_name)
 
         # Reset the scenes in case they were changed
-        context.scene.head = head.name
-        context.scene.eye_left = old_eye_left.name
-        context.scene.eye_right = old_eye_right.name
+        context.scene.head = head_name
+        context.scene.eye_left = old_eye_left_name
+        context.scene.eye_right = old_eye_right_name
         context.scene.wink_left = shapes[0]
         context.scene.wink_right = shapes[1]
         context.scene.lowerlid_left = shapes[2]
@@ -234,8 +243,8 @@ class CreateEyesButton(bpy.types.Operator):
             repair_shapekeys_mouth(mesh_name)
             # repair_shapekeys_mouth(mesh_name, context.scene.wink_left)  # TODO
         else:
-            # print('Repair normal "' + new_right_eye.name + '".')
-            repair_shapekeys(mesh_name, new_right_eye.name)
+            # print('Repair normal "' + new_right_eye_name + '".')
+            repair_shapekeys(mesh_name, new_right_eye_name)
 
         # deleted = []
         # # deleted = checkshapekeys()


### PR DESCRIPTION
This is a small patch to fix a `UnicodeDecodeError` that was brought up by a user on Discord when they were creating eye tracking (I successfully reproduced it after a few tries):
![image](https://user-images.githubusercontent.com/495015/177020079-d0791bc9-0286-451a-8bcb-1aaa43ca5cc7.png)
Getting a `UnicodeDecodeError` when getting a `name` attribute typically happens when trying to use a variable where Blender has already freed its memory.
Sometimes, such code will work fine as the memory hasn't been overwritten yet, but other times the `name` attribute will now be some other random memory, so there may be unexpected results, errors may occur (such as this) or rarely, Blender could crash.

In this particular case, references to `EditBone`s were still being used after switching to `OBJECT` mode from `EDIT` mode, which frees the memory of the `EditBone`s.

To fix the issue, I have created separate variables for the needed attributes of the `EditBone`s, prior to to the switch to `OBJECT` mode.