### PR TITLE
Fixes issue #509 and probably #258 too

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -408,6 +408,8 @@ def unregister():
     if file_dir in sys.path:
         sys.path.remove(file_dir)
 
+    tools.settings.stop_apply_settings_threads()
+
     print("### Unloaded CATS successfully!\n")
 
 

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -47,6 +47,7 @@ settings_file = os.path.join(resources_dir, "settings.json")
 
 settings_data = None
 settings_data_unchanged = None
+settings_threads = []
 
 # Settings name = [Default Value, Require Blender Restart]
 settings_default = OrderedDict()
@@ -205,10 +206,20 @@ def reset_settings(full_reset=False, to_reset_settings=None):
 
 
 def start_apply_settings_timer():
-    global lock_settings
+    global lock_settings, settings_threads
     lock_settings = True
     thread = Thread(target=apply_settings, args=[])
+    settings_threads.append(thread)
     thread.start()
+
+
+def stop_apply_settings_threads():
+    global settings_threads
+
+    print("Stopping settings threads...")
+    for t in settings_threads:
+        t.join()
+    print("Settings threads stopped.")
 
 
 def apply_settings():


### PR DESCRIPTION
This change stops the started "thread" timer for apply settings when CATS addon is shutdown. Not stopping the thread(s) causes Blender to segfault when ran headless.

Related issues:
- #509
- #258 (probably)