### PR TITLE
Fixes an annoying warning message written on stderr related to update settings

### DIFF
--- a/tools/settings.py
+++ b/tools/settings.py
@@ -258,6 +258,10 @@ def settings_changed():
 
 
 def update_settings(self, context):
+    update_settings_core(self, context)
+
+
+def update_settings_core(self, context):
     # Use False and None for this variable, because Blender would complain otherwise
     # None means that the settings did change
     settings_changed_tmp = False

--- a/tools/translations.py
+++ b/tools/translations.py
@@ -84,7 +84,7 @@ def get_languages_list(self, context):
 
 
 def update_ui(self, context):
-    if settings.update_settings(None, None):
+    if settings.update_settings_core(None, None):
         reload_scripts()
 
 


### PR DESCRIPTION
I renamed the function `update_settings` to `update_settings_core` so this one behaves the same as the original, and I create a `update_settings` function that call the core one but discards the return value. So code that cares about the return value calls the core one, and Blender can call the original that now always return `None`, and everyone is happy.