### PR TITLE
fix TypeError: WindowManager.invoke_props_dialog(): error with keyword argument "width" -  Function.width expected an int type, not float

### DIFF
--- a/tools/common.py
+++ b/tools/common.py
@@ -1667,7 +1667,7 @@ class ShowError(bpy.types.Operator):
 
     def invoke(self, context, event):
         dpi_value = Common.get_user_preferences().system.dpi
-        return context.window_manager.invoke_props_dialog(self, width=dpi_value * dpi_scale)
+        return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * dpi_scale))
 
     def draw(self, context):
         if not error or len(error) == 0:

--- a/tools/importer.py
+++ b/tools/importer.py
@@ -963,7 +963,7 @@ class ErrorDisplay(bpy.types.Operator):
         self.eye_meshes_not_named_body = _eye_meshes_not_named_body
 
         dpi_value = Common.get_user_preferences().system.dpi
-        return context.window_manager.invoke_props_dialog(self, width=dpi_value * 6.1)
+        return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * 6.1))
 
     def check(self, context):
         # Important for changing options

--- a/ui/armature.py
+++ b/ui/armature.py
@@ -202,7 +202,7 @@ class ModelSettings(bpy.types.Operator):
 
     def invoke(self, context, event):
         dpi_value = Common.get_user_preferences().system.dpi
-        return context.window_manager.invoke_props_dialog(self, width=dpi_value * 3.25)
+        return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * 3.25))
 
     def check(self, context):
         # Important for changing options


### PR DESCRIPTION
Fix Error When Exportting Model
- TypeError: WindowManager.invoke_props_dialog(): error with keyword argument "width" -  Function.width expected an int type, not float

change context.window_manager.invoke_props_dialog width to int
```
# tools/common.py
return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * dpi_scale))

# tools/importer.py
return context.window_manager.invoke_props_dialog(self, width=int(dpi_value * 6.1))
```

