### PR TITLE
Fix Cats failing to load on Blender 3.5

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -306,7 +306,7 @@ def register():
     else:
         pass  # From 2.83 on this is no longer needed
     tools.common.get_user_preferences().filepaths.use_file_compression = True
-    bpy.context.window_manager.addon_support = {'OFFICIAL', 'COMMUNITY', 'TESTING'}
+    bpy.context.window_manager.addon_support = {'OFFICIAL', 'COMMUNITY'}
 
     # Add shapekey button to shapekey menu
     if hasattr(bpy.types, 'MESH_MT_shape_key_specials'):  # pre 2.80


### PR DESCRIPTION
The 'TESTING' category for addons is no longer present in non-alpha builds of Blender as of Blender 3.5.

----

Details in the Blender 3.5 patch notes at the end of https://wiki.blender.org/wiki/Reference/Release_Notes/3.5/Add-ons
Also, the commit in Blender that made the change: https://projects.blender.org/blender/blender/commit/e8c7866608bb

Note that Blender 3.5 is currently in beta and is planned to be released on March 29th.

Error from a user on discord:
![image](https://user-images.githubusercontent.com/495015/225478905-99b73ffd-88a6-43d5-ab8c-1c2eb0a39a07.png)
