### PR TITLE
Revert "Add decimate option to not join meshes after decimation"

### DIFF
--- a/resources/translations.csv
+++ b/resources/translations.csv
@@ -1000,8 +1000,6 @@ Results in better animating topology by trading off overall shape accuracy
 Use if your elbows/joints end up with bad topology",,
 Scene.decimation_animation_weighting_factor.label,Factor,,
 Scene.decimation_animation_weighting_factor.desc,How much influence the animation weighting has on the overall shape,,
-Scene.decimation_retain_separated_meshes.label,Retain Separated Meshes,,
-Scene.decimation_retain_separated_meshes.desc,Experimental option. Keep existing meshes as separate objects throughout decimation,,
 Scene.max_tris.label,Tris,トリス,삼각폴리곤(Tris)
 Scene.max_tris.desc,The target amount of tris after decimation,,
 Scene.eye_mode.label,Eye Mode,アイモード,

--- a/ui/decimation.py
+++ b/ui/decimation.py
@@ -161,8 +161,6 @@ class DecimationPanel(ToolPanel, bpy.types.Panel):
             row.prop(context.scene, 'decimation_animation_weighting_include_shapekeys', expand=True)
             col.separator()
         row = col.row(align=True)
-        row.prop(context.scene, 'decimation_retain_separated_meshes', expand=True)
-        row = col.row(align=True)
         row.operator(Decimation.AutoDecimatePresetGood.bl_idname)
         row.operator(Decimation.AutoDecimatePresetExcellent.bl_idname)
         row.operator(Decimation.AutoDecimatePresetQuest.bl_idname)


### PR DESCRIPTION
Reverts absolute-quantum/cats-blender-plugin#551

```
Python: Traceback (most recent call last):
  File "/home/feilen/.config/blender/3.4/scripts/addons/cats/tools/bake.py", line 768, in execute
    self.perform_bake(context)
  File "/home/feilen/.config/blender/3.4/scripts/addons/cats/tools/bake.py", line 1940, in perform_bake
    bpy.ops.cats_decimation.auto_decimate(armature_name=plat_arm_copy.name, preserve_seams=preserve_seams, seperate_materials=False)
  File "/snap/blender/3132/3.4/scripts/modules/bpy/ops.py", line 113, in __call__
    ret = _op_call(self.idname_py(), None, kw)
RuntimeError: Error: Python: Traceback (most recent call last):
  File "/home/feilen/.config/blender/3.4/scripts/addons/cats/tools/decimation.py", line 149, in execute
    if not context.scene.decimation_retain_separated_meshes:
AttributeError: 'Scene' object has no attribute 'decimation_retain_separated_meshes'
Location: /snap/blender/3132/3.4/scripts/modules/bpy/ops.py:113
```