### PR TITLE
Fix mirror mode breaking merge bones

### DIFF
--- a/tools/armature_manual.py
+++ b/tools/armature_manual.py
@@ -792,6 +792,9 @@ class MergeWeights(bpy.types.Operator):
 
         Common.switch('EDIT')
 
+        armature.data.use_mirror_x = False #<- fixes merge bones issues - @989onan
+        armature.pose.use_mirror_x = False #<- fixes merge bones issues - @989onan
+
         # Find which bones to work on and put their name and their parent in a list
         parenting_list = {}
         for bone in context.selected_editable_bones:
@@ -838,6 +841,9 @@ class MergeWeightsToActive(bpy.types.Operator):
         armature = bpy.context.object
 
         Common.switch('EDIT')
+
+        armature.data.use_mirror_x = False #<- fixes merge bones issues - @989onan
+        armature.pose.use_mirror_x = False #<- fixes merge bones issues - @989onan
 
         # Find which bones to work on and put their name and their parent in a list and parent the bones to the active one
         parenting_list = {}

--- a/tools/common.py
+++ b/tools/common.py
@@ -272,6 +272,8 @@ def set_default_stage():
     armature = get_armature()
     if armature:
         set_active(armature)
+        armature.data.use_mirror_x = False #<- fixes merge bones issues - @989onan
+        armature.pose.use_mirror_x = False #<- fixes merge bones issues - @989onan
         if version_2_79_or_older():
             armature.layers[0] = True
 


### PR DESCRIPTION
Mirror mode being on breaks merge bones by auto deleting or mirroring the armature. We can let the end user merge the other side manually, instead of having them depending on mirror and merging one side and expecting cats to merge the other and/or account for mirror mode.