### PR TITLE
Fix for Blender 3.5.0 __init__ install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ resources/icons/supporters/**
 resources/supporters.json
 .coverage
 mmd_tools_local2
+/.vs/VSWorkspaceState.json
+/.vs/slnx.sqlite
+/.vs/Cats-Blender-Plugin/FileContentIndex
+*.wsuo

--- a/__init__.py
+++ b/__init__.py
@@ -333,7 +333,7 @@ def unregister():
     updater.unregister()
 
     # Register unloaded mmd_tools tabs if they are hidden to avoid issues when unloading mmd_tools
-    if not bpy.context.scene.show_mmd_tabs:
+    if not bpy.context.window.scene.show_mmd_tabs:
         tools.common.toggle_mmd_tabs(shutdown_plugin=True)
 
     # Unload mmd_tools


### PR DESCRIPTION
Simply changes init line 336 to fix the addon launch error

from
`if not bpy.context.scene.show_mmd_tabs:`

to
`if not bpy.context.window.scene.show_mmd_tabs:`