### PR TITLE
Fix broken Japanese text in search operator popups

### DIFF
--- a/ui/bone_root.py
+++ b/ui/bone_root.py
@@ -6,6 +6,7 @@ from .main import ToolPanel
 from ..tools import rootbone as Rootbone
 from ..tools.register import register_wrap
 from ..tools.translations import t
+from ..tools.common import wrap_dynamic_enum_items
 
 
 @register_wrap
@@ -15,7 +16,14 @@ class SearchMenuOperator_root_bone(bpy.types.Operator):
     bl_label = ""#t('Scene.root_bone.label')
     bl_property = "my_enum"
 
-    my_enum: bpy.props.EnumProperty(name=t('Scene.root_bone.label'),description= t('Scene.root_bone.desc'), items=Rootbone.get_parent_root_bones)
+    my_enum: bpy.props.EnumProperty(
+        name=t('Scene.root_bone.label'),
+        description=t('Scene.root_bone.desc'),
+        # get_parent_root_bones caches results so the wrapper cannot run in-place
+        items=wrap_dynamic_enum_items(
+            Rootbone.get_parent_root_bones, bl_idname, sort=False, in_place=False, is_holder=False
+        ),
+    )
     
     def execute(self, context):
         context.scene.root_bone = self.my_enum

--- a/ui/custom.py
+++ b/ui/custom.py
@@ -19,7 +19,11 @@ class SearchMenuOperator_merge_armature_into(bpy.types.Operator):
     bl_label = ""
     bl_property = "my_enum"
 
-    my_enum: bpy.props.EnumProperty(name=t('Scene.merge_armature_into.label'), description=t('Scene.merge_armature_into.desc'), items=Common.get_armature_list)
+    my_enum: bpy.props.EnumProperty(
+        name=t('Scene.merge_armature_into.label'),
+        description=t('Scene.merge_armature_into.desc'),
+        items=Common.wrap_dynamic_enum_items(Common.get_armature_list, bl_idname, is_holder=False),
+    )
 
     def execute(self, context):
         context.scene.merge_armature_into = self.my_enum
@@ -38,7 +42,11 @@ class SearchMenuOperator_merge_armature(bpy.types.Operator):
     bl_label = t('Scene.root_bone.label')
     bl_property = "my_enum"
 
-    my_enum: bpy.props.EnumProperty(name=t('Scene.merge_armature.label'), description= t('Scene.merge_armature.desc'), items=Common.get_armature_merge_list)
+    my_enum: bpy.props.EnumProperty(
+        name=t('Scene.merge_armature.label'),
+        description=t('Scene.merge_armature.desc'),
+        items=Common.wrap_dynamic_enum_items(Common.get_armature_merge_list, bl_idname, is_holder=False),
+    )
 
     def execute(self, context):
         context.scene.merge_armature = self.my_enum
@@ -57,7 +65,12 @@ class SearchMenuOperator_attach_to_bone(bpy.types.Operator):
     bl_label = ""
     bl_property = "my_enum"
 
-    my_enum: bpy.props.EnumProperty(name=t('Scene.attach_to_bone.label'), description= t('Scene.attach_to_bone.desc'), items=Common.get_bones_merge)
+    my_enum: bpy.props.EnumProperty(
+        name=t('Scene.attach_to_bone.label'),
+        description=
+        t('Scene.attach_to_bone.desc'),
+        items=Common.wrap_dynamic_enum_items(Common.get_bones_merge, bl_idname, sort=False, is_holder=False),
+    )
 
     def execute(self, context):
         context.scene.attach_to_bone = self.my_enum
@@ -76,7 +89,12 @@ class SearchMenuOperator_attach_mesh(bpy.types.Operator):
     bl_label = ""
     bl_property = "my_enum"
 
-    my_enum: bpy.props.EnumProperty(name=t('Scene.attach_mesh.label'), description= t('Scene.attach_mesh.desc'), items=Common.get_top_meshes)
+    my_enum: bpy.props.EnumProperty(
+        name=t('Scene.attach_mesh.label'),
+        description=
+        t('Scene.attach_mesh.desc'),
+        items=Common.wrap_dynamic_enum_items(Common.get_top_meshes, bl_idname, is_holder=False),
+    )
 
     def execute(self, context):
         context.scene.attach_mesh = self.my_enum

--- a/ui/eye_tracking.py
+++ b/ui/eye_tracking.py
@@ -17,7 +17,10 @@ class SearchMenuOperatorBoneHead(bpy.types.Operator):
     bl_label = ""
     bl_property = "my_enum"
 
-    my_enum: bpy.props.EnumProperty(name="shapekeys", items=Common.get_bones_head)
+    my_enum: bpy.props.EnumProperty(
+        name="shapekeys",
+        items=Common.wrap_dynamic_enum_items(Common.get_bones_head, bl_idname, is_holder=False),
+    )
 
     def execute(self, context):
         context.scene.head = self.my_enum
@@ -36,7 +39,10 @@ class SearchMenuOperatorBoneEyeLeft(bpy.types.Operator):
     bl_label = ""
     bl_property = "my_enum"
 
-    my_enum: bpy.props.EnumProperty(name="shapekeys", items=Common.get_bones_eye_l)
+    my_enum: bpy.props.EnumProperty(
+        name="shapekeys",
+        items=Common.wrap_dynamic_enum_items(Common.get_bones_eye_l, bl_idname, is_holder=False),
+    )
 
     def execute(self, context):
         context.scene.eye_left = self.my_enum
@@ -55,7 +61,10 @@ class SearchMenuOperatorBoneEyeRight(bpy.types.Operator):
     bl_label = ""
     bl_property = "my_enum"
 
-    my_enum: bpy.props.EnumProperty(name="shapekeys", items=Common.get_bones_eye_r)
+    my_enum: bpy.props.EnumProperty(
+        name="shapekeys",
+        items=Common.wrap_dynamic_enum_items(Common.get_bones_eye_r, bl_idname, is_holder=False),
+    )
 
     def execute(self, context):
         context.scene.eye_right = self.my_enum
@@ -74,7 +83,10 @@ class SearchMenuOperatorShapekeyWinkLeft(bpy.types.Operator):
     bl_label = ""
     bl_property = "my_enum"
 
-    my_enum: bpy.props.EnumProperty(name="shapekeys", items=Common.get_shapekeys_eye_blink_l)
+    my_enum: bpy.props.EnumProperty(
+        name="shapekeys",
+        items=Common.wrap_dynamic_enum_items(Common.get_shapekeys_eye_blink_l, bl_idname, sort=False, is_holder=False),
+    )
 
     def execute(self, context):
         context.scene.wink_left = self.my_enum
@@ -93,7 +105,10 @@ class SearchMenuOperatorShapekeyWinkRight(bpy.types.Operator):
     bl_label = ""
     bl_property = "my_enum"
 
-    my_enum: bpy.props.EnumProperty(name="shapekeys", items=Common.get_shapekeys_eye_blink_r)
+    my_enum: bpy.props.EnumProperty(
+        name="shapekeys",
+        items=Common.wrap_dynamic_enum_items(Common.get_shapekeys_eye_blink_r, bl_idname, sort=False, is_holder=False),
+    )
 
     def execute(self, context):
         context.scene.wink_right = self.my_enum
@@ -112,7 +127,10 @@ class SearchMenuOperatorShapekeyLowerLidLeft(bpy.types.Operator):
     bl_label = ""
     bl_property = "my_enum"
 
-    my_enum: bpy.props.EnumProperty(name="shapekeys", items=Common.get_shapekeys_eye_low_l)
+    my_enum: bpy.props.EnumProperty(
+        name="shapekeys",
+        items=Common.wrap_dynamic_enum_items(Common.get_shapekeys_eye_low_l, bl_idname, sort=False, is_holder=False),
+    )
 
     def execute(self, context):
         context.scene.lowerlid_left = self.my_enum
@@ -131,7 +149,10 @@ class SearchMenuOperatorShapekeyLowerLidRight(bpy.types.Operator):
     bl_label = ""
     bl_property = "my_enum"
 
-    my_enum: bpy.props.EnumProperty(name="shapekeys", items=Common.get_shapekeys_eye_low_r)
+    my_enum: bpy.props.EnumProperty(
+        name="shapekeys",
+        items=Common.wrap_dynamic_enum_items(Common.get_shapekeys_eye_low_r, bl_idname, sort=False, is_holder=False),
+    )
 
     def execute(self, context):
         context.scene.lowerlid_right = self.my_enum

--- a/ui/visemes.py
+++ b/ui/visemes.py
@@ -17,7 +17,11 @@ class SearchMenuOperatorMouthA(bpy.types.Operator):
     bl_label = ""
     bl_property = "my_enum"
 
-    my_enum: bpy.props.EnumProperty(name="shapekeys", description=t('Scene.mouth_a.desc'), items=Common.get_shapekeys_mouth_ah) #default, change after making operator in UI like shown below.7
+    my_enum: bpy.props.EnumProperty(
+        name="shapekeys",
+        description=t('Scene.mouth_a.desc'),
+        items=Common.wrap_dynamic_enum_items(Common.get_shapekeys_mouth_ah, bl_idname, sort=False, is_holder=False),
+    )
 
     def execute(self, context):
         context.scene.mouth_a = self.my_enum
@@ -36,7 +40,11 @@ class SearchMenuOperatorMouthO(bpy.types.Operator):
     bl_label = ""
     bl_property = "my_enum"
 
-    my_enum: bpy.props.EnumProperty(name="shapekeys", description=t('Scene.mouth_o.desc'), items=Common.get_shapekeys_mouth_oh) #default, change after making operator in UI like shown below.7
+    my_enum: bpy.props.EnumProperty(
+        name="shapekeys",
+        description=t('Scene.mouth_o.desc'),
+        items=Common.wrap_dynamic_enum_items(Common.get_shapekeys_mouth_oh, bl_idname, sort=False, is_holder=False),
+    )
 
     def execute(self, context):
         context.scene.mouth_o = self.my_enum
@@ -55,7 +63,11 @@ class SearchMenuOperatorMouthCH(bpy.types.Operator):
     bl_label = ""
     bl_property = "my_enum"
 
-    my_enum: bpy.props.EnumProperty(name="shapekeys", description=t('Scene.mouth_ch.desc'), items=Common.get_shapekeys_mouth_ch) #default, change after making operator in UI like shown below.7
+    my_enum: bpy.props.EnumProperty(
+        name="shapekeys",
+        description=t('Scene.mouth_ch.desc'),
+        items=Common.wrap_dynamic_enum_items(Common.get_shapekeys_mouth_ch, bl_idname, sort=False, is_holder=False),
+    )
 
     def execute(self, context):
         context.scene.mouth_ch = self.my_enum


### PR DESCRIPTION
Another issue with dynamic enum properties.

Without ensuring that Python kept reference to the strings in the enum for each search operator, strings containing Japanese characters were displaying random memory. Attempting to select an option would actually try to use that random memory as the string to set, so the issue was not purely visual.

This patch wraps all search operators' enum `items` functions in `wrap_dynamic_enum_items` to ensure that Python keeps reference to the strings.

`wrap_dynamic_enum_items` has been modified specifically for search operators to allow for instances that are not part of a scene or otherwise do not hold the property they reference. To keep the caches of names unique per search operator, their `bl_idname`s have been used as the keys used by the string cache.

----

Thanks to MdNight_(Kilia FinClub) for reporting the bug on discord.
This fixes shape keys/bones/etc. showing up in search operator popups like this
![image](https://user-images.githubusercontent.com/495015/234442456-46dd825e-4dee-4603-9e26-a1a994d0ab20.png)
