### PR TITLE
Removing "Testing" tag for new blender

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -316,7 +316,7 @@ def register():
     else:
         pass  # From 2.83 on this is no longer needed
     tools.common.get_user_preferences().filepaths.use_file_compression = True
-    bpy.context.window_manager.addon_support = {'OFFICIAL', 'COMMUNITY', 'TESTING'}
+    bpy.context.window_manager.addon_support = {'OFFICIAL', 'COMMUNITY'}
 
     # Add shapekey button to shapekey menu
     if hasattr(bpy.types, 'MESH_MT_shape_key_specials'):  # pre 2.80


### PR DESCRIPTION
Removing "Testing" tag for blender version 3.5.1.