### PR TITLE
Remove unselect_all when deleting hierarchy

### DIFF
--- a/tools/common.py
+++ b/tools/common.py
@@ -1349,7 +1349,6 @@ def removeZeroVerts(obj, thres=0):
             obj.vertex_groups[g.group].remove([v.index])
 
 def delete_hierarchy(parent):
-    unselect_all()
     to_delete = []
 
     def get_child_names(obj):


### PR DESCRIPTION
The `unselect_all()` function is indirectly called multiple times within the `remove_unused_objects()` function, like this:

```python
for obj_remove in default_scene_objects:
    for obj in bpy.context.view_layer.objects:
        select(obj, False)
    bpy.context.view_layer.objects.remove(obj_remove)
```

This can result in the select function being applied to an empty object during the second iteration (#610). To address this, we can update the objects after each iteration:

```python
for obj_remove in default_scene_objects:
    ...
    bpy.context.view_layer.update()
```

It appears unnecessary to deselect all objects when removing an object from the global objects, so simply removing the `unselect_all()` from the `delete_hierarchy()` should suffice.