### PR TITLE
Add support for bone collections in Blender 4.0

### DIFF
--- a/resources/translations.csv
+++ b/resources/translations.csv
@@ -65,7 +65,7 @@ ToolPanel.category,CATS,,
 ArmaturePanel.label,Model,モデル,모델
 ArmaturePanel.warn.newBlender1,Potentially unsupported Blender version detected!
 ArmaturePanel.warn.newBlender2,Some features might not work!
-ArmaturePanel.warn.newBlender3,CATS currently supports up to Blender 3.5.
+ArmaturePanel.warn.newBlender3,CATS currently supports up to Blender 4.0.
 ArmaturePanel.warn.oldBlender1,Old Blender version detected!,古いブレンダーバージョンが検出されました!,이전 블렌더 버전이 발견되었습니다!
 ArmaturePanel.warn.oldBlender2,Some features might not work!,一部の機能は動作しない可能性があります!,일부 기능이 작동하지 않을 수 있습니다!
 ArmaturePanel.warn.oldBlender3,Please update to Blender 2.79!,ブレンダー2.79以上にアップデートしてください!,블렌더 2.79 버전으로 업데이트하세요!

--- a/tools/armature.py
+++ b/tools/armature.py
@@ -9,6 +9,7 @@ from . import common as Common
 from . import translate as Translate
 from . import armature_bones as Bones
 from .common import version_2_79_or_older
+from .common import version_3_6_or_older
 from .register import register_wrap
 from .translations import t
 
@@ -493,9 +494,13 @@ class FixArmature(bpy.types.Operator):
         if bpy.ops.mesh.reveal.poll():
             bpy.ops.mesh.reveal()
 
-        # Remove Bone Groups
-        for group in armature.pose.bone_groups:
-            armature.pose.bone_groups.remove(group)
+        # Remove Bone Groups or Collections
+        if version_3_6_or_older():
+            for group in armature.pose.bone_groups:
+                armature.pose.bone_groups.remove(group)
+        else:
+            for collection in armature.data.collections:
+                armature.data.collections.remove(collection)
 
         # Bone constraints should be deleted
         # if context.scene.remove_constraints:
@@ -512,7 +517,8 @@ class FixArmature(bpy.types.Operator):
                     steps += 1
                 else:
                     steps -= 1
-            bone.layers[0] = True
+            if version_3_6_or_older():
+                bone.layers[0] = True
 
         # Start loading bar
         current_step = 0

--- a/tools/armature_bones.py
+++ b/tools/armature_bones.py
@@ -591,6 +591,8 @@ bone_rename['\Left shoulder'] = [
     'Bip_Collar_\L',
     'B_\L_Shoulder',
     '\LCollar',
+    'Collar\L',
+    'Collar_\L',
     '\L_Clavicle',
     '\L_Clavicle1',
     '\Left_Clavicle',

--- a/tools/common.py
+++ b/tools/common.py
@@ -41,6 +41,9 @@ def version_2_79_or_older():
 def version_2_93_or_older():
     return bpy.app.version < (2, 90)
 
+def version_3_6_or_older():
+    return bpy.app.version < (3, 7)
+
 
 def get_objects():
     return bpy.context.scene.objects if version_2_79_or_older() else bpy.context.view_layer.objects

--- a/ui/armature.py
+++ b/ui/armature.py
@@ -43,7 +43,7 @@ class ArmaturePanel(ToolPanel, bpy.types.Panel):
             col.separator()
             col.separator()
 
-        if bpy.app.version > (3, 5, 99):
+        if bpy.app.version > (4, 0, 99):
             col.separator()
             row = col.row(align=True)
             row.scale_y = 0.75


### PR DESCRIPTION
Adds version check for 3.6 and lower in common utils.
Changes calls from bone layers to bone collections for 4.0 and higher.