### PR TITLE
Update for changes in Blender 4.0

### DIFF
--- a/tools/armature.py
+++ b/tools/armature.py
@@ -510,13 +510,35 @@ class FixArmature(bpy.types.Operator):
 
         # Count steps for loading bar again and reset the layers
         steps += len(armature.data.edit_bones)
+        if Common.version_3_6_or_older:
+            def set_bone_visible(edit_bone):
+                edit_bone.layers[0] = True
+        else:
+            # Armature/Bone layers were replaced with Bone Collections in Blender 4.0.
+            bone_collections = armature.data.collections
+            if not bone_collections:
+                # All bones are visible when there are no bone collections, so nothing to do.
+                def set_bone_visible(_edit_bone):
+                    pass
+            else:
+                # The default collection on new Armatures is called "Bones" and usually has all bones assigned to it.
+                default_collection_name = "Bones"
+                bone_collection = bone_collections.get(default_collection_name)
+                if bone_collection is None:
+                    # The default "Bones" collection does not exist, create it.
+                    bone_collection = bone_collections.new(default_collection_name)
+                # Ensure the collection is visible.
+                bone_collection.is_visible = True
+
+                def set_bone_visible(edit_bone):
+                    bone_collection.assign(edit_bone)
         for bone in armature.data.edit_bones:
             if bone.name in Bones.bone_list or bone.name.startswith(tuple(Bones.bone_list_with)):
                 if bone.parent is not None:
                     steps += 1
                 else:
                     steps -= 1
-            bone.layers[0] = True
+            set_bone_visible(bone)
 
         # Start loading bar
         current_step = 0

--- a/tools/armature.py
+++ b/tools/armature.py
@@ -494,8 +494,12 @@ class FixArmature(bpy.types.Operator):
             bpy.ops.mesh.reveal()
 
         # Remove Bone Groups
-        for group in armature.pose.bone_groups:
-            armature.pose.bone_groups.remove(group)
+        # Replaced in 4.0 with Bone Collections (Armature.collections), which also subsumed Armature.layers. Bone colors
+        # are now defined per-bone, Bone.color.palette and PoseBone.color.palette
+        if Common.version_3_6_or_older:
+            bone_groups = armature.pose.bone_groups
+            for group in bone_groups:
+                bone_groups.remove(group)
 
         # Bone constraints should be deleted
         # if context.scene.remove_constraints:

--- a/tools/armature_manual.py
+++ b/tools/armature_manual.py
@@ -388,7 +388,7 @@ class PoseToRest(bpy.types.Operator):
         # active object e.g., the user has multiple armatures opened in pose mode, but a different armature is currently
         # active. We can use an operator override to tell the operator to treat armature_obj as if it's the active
         # object even if it's not, skipping the need to actually set armature_obj as the active object.
-        bpy.ops.pose.armature_apply({'active_object': armature_obj})
+        Common.op_override(bpy.ops.pose.armature_apply, {'active_object': armature_obj})
 
         # Stop pose mode after operation
         bpy.ops.cats_manual.stop_pose_mode()
@@ -411,14 +411,14 @@ class PoseToRest(bpy.types.Operator):
         # first and potentially having unexpected results.
         if bpy.app.version >= (2, 90, 0):
             # modifier_move_to_index was added in Blender 2.90
-            bpy.ops.object.modifier_move_to_index(context_override, modifier=mod_name, index=0)
+            Common.op_override(bpy.ops.object.modifier_move_to_index, context_override, modifier=mod_name, index=0)
         else:
             # The newly created modifier will be at the bottom of the list
             armature_mod_index = len(mesh_obj.modifiers) - 1
             # Move the modifier up until it's at the top of the list
             for _ in range(armature_mod_index):
-                bpy.ops.object.modifier_move_up(context_override, modifier=mod_name)
-        bpy.ops.object.modifier_apply(context_override, modifier=mod_name)
+                Common.op_override(bpy.ops.object.modifier_move_up, context_override, modifier=mod_name)
+        Common.op_override(bpy.ops.object.modifier_apply, context_override, modifier=mod_name)
 
     @staticmethod
     def apply_armature_to_mesh_with_shape_keys(armature_obj, mesh_obj, scene):

--- a/tools/common.py
+++ b/tools/common.py
@@ -42,6 +42,9 @@ def version_2_93_or_older():
     return bpy.app.version < (2, 90)
 
 
+version_3_6_or_older = bpy.app.version < (4, 0)
+
+
 def get_objects():
     return bpy.context.scene.objects if version_2_79_or_older() else bpy.context.view_layer.objects
 


### PR DESCRIPTION
Blender 4.0 removed bone layers and bone groups, replacing them with Bone Collections.

This patch adds a "Blender 3.6 or older" check and uses new Bone Collection code when using Blender 4.0.

Bone collections are not removed like bone groups were because they are the direct replacement for armature/bone layers, which were not removed before. The bone color properties of bone groups were instead replaced in 4.0 by setting each bone's color individually. This patch does not modify bone colors like removing bone groups would have done in older versions.

---

Blender 4.0 replaced the ability to call operators with a context override argument with `Context.temp_override`.

A new version-independent function for calling operators with context overrides has been added to common.py and code has been updated to use this new function.

---

It should be noted that mmd tools is broken in many areas with the update to 4.0, but the upstream mmd tools repository is yet to update for 4.0: https://github.com/UuuNyaa/blender_mmd_uuunyaa_tools. Though note that mmd tools' priority is supporting the latest LTS release, which 4.0 is not, so mmd tools updating could take some time. https://mmd-blender.fandom.com/wiki/MMD_UuuNyaa_Tools#Requirements