### PR TITLE
Update __init__.py, no longer errors in blender 4.1

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -316,7 +316,7 @@ def register():
     else:
         pass  # From 2.83 on this is no longer needed
     tools.common.get_user_preferences().filepaths.use_file_compression = True
-    bpy.context.window_manager.addon_support = {'OFFICIAL', 'COMMUNITY', 'TESTING'}
+    bpy.context.window_manager.addon_support = {'OFFICIAL', 'COMMUNITY'}
 
     # Add shapekey button to shapekey menu
     if hasattr(bpy.types, 'MESH_MT_shape_key_specials'):  # pre 2.80


### PR DESCRIPTION
It gave an error when trying to import into blender 4.1, so i have removed it. (i know its a bit temporary fix)